### PR TITLE
Remove compiler from cmakelists and run clang format.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.15.0)
 
-PROJECT(MultiphaseStokes LANGUAGES C CXX Fortran)
+PROJECT(MultiphaseStokes LANGUAGES C CXX)
 FIND_PACKAGE(IBAMR REQUIRED)
 
 SET(CXX_SRC
@@ -8,14 +8,15 @@ SET(CXX_SRC
     VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
     )
 
-SET(CMAKE_CXX_COMPILER
-   /export/spack/linux-centos7-x86_64/gcc-7.5.0/mpich-3.4.2-wj5qtlnmxknr7oycz5wblj3iwsbpgc3m/bin/mpicxx
-   )
 
-ADD_EXECUTABLE(main2d main.cpp)
+ADD_EXECUTABLE(apply2d apply.cpp)
+TARGET_SOURCES(apply2d PRIVATE ${CXX_SRC})
+TARGET_LINK_LIBRARIES(apply2d IBAMR::IBAMR2d)
+
 ADD_EXECUTABLE(solver2d solver.cpp)
-TARGET_SOURCES(main2d PRIVATE ${CXX_SRC})
-TARGET_LINK_LIBRARIES(main2d IBAMR::IBAMR2d)
 TARGET_SOURCES(solver2d PRIVATE ${CXX_SRC})
 TARGET_LINK_LIBRARIES(solver2d IBAMR::IBAMR2d)
+
 CONFIGURE_FILE(input2d_four ${CMAKE_CURRENT_BINARY_DIR}/input2d_four COPYONLY)
+
+

--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
@@ -13,22 +13,22 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
-#include "VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h"
 #include "ibtk/CCPoissonSolverManager.h"
 #include "ibtk/CartCellDoubleCubicCoarsen.h"
 #include "ibtk/CartCellDoubleQuadraticCFInterpolation.h"
 #include "ibtk/CartCellRobinPhysBdryOp.h"
 #include "ibtk/CellNoCornersFillPattern.h"
 #include "ibtk/CoarseFineBoundaryRefinePatchStrategy.h"
+#include "ibtk/FACPreconditionerStrategy.h"
 #include "ibtk/HierarchyGhostCellInterpolation.h"
 #include "ibtk/HierarchyMathOps.h"
 #include "ibtk/LinearSolver.h"
 #include "ibtk/PETScKrylovLinearSolver.h"
 #include "ibtk/PETScLevelSolver.h"
-#include "ibtk/FACPreconditionerStrategy.h"
 #include "ibtk/PoissonSolver.h"
 #include "ibtk/RobinPhysBdryPatchStrategy.h"
 #include "ibtk/ibtk_utilities.h"
+#include "ibtk/namespaces.h" // IWYU pragma: keep
 
 #include "Box.h"
 #include "BoxList.h"
@@ -53,6 +53,8 @@
 
 #include "petscksp.h"
 
+#include <Eigen/LU>
+
 #include <algorithm>
 #include <cstring>
 #include <memory>
@@ -60,12 +62,12 @@
 #include <string>
 #include <vector>
 
-#include "ibtk/namespaces.h" // IWYU pragma: keep
+// Local includes
+#include "VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 namespace IBTK
 {
-    
 /////////////////////////////// STATIC ///////////////////////////////////////
 namespace
 {
@@ -82,8 +84,12 @@ static const int CELLG = 1;
 
 // Types of refining and coarsening to perform prior to setting coarse-fine
 // boundary and physical boundary ghost cell values.
-static const std::string CC_DATA_REFINE_TYPE = "CONSERVATIVE_LINEAR_REFINE"; // how to fill in fine cells from coarse cells, how to fill ghost cells on refine patch
-static const std::string SC_DATA_REFINE_TYPE = "CONSERVATIVE_LINEAR_REFINE"; // how to fill in fine cells from coarse cells, how to fill ghost cells on refine patch
+static const std::string CC_DATA_REFINE_TYPE =
+    "CONSERVATIVE_LINEAR_REFINE"; // how to fill in fine cells from coarse cells, how to fill ghost cells on refine
+                                  // patch
+static const std::string SC_DATA_REFINE_TYPE =
+    "CONSERVATIVE_LINEAR_REFINE"; // how to fill in fine cells from coarse cells, how to fill ghost cells on refine
+                                  // patch
 static const std::string DATA_REFINE_TYPE = "NONE";
 static const bool USE_CF_INTERPOLATION = true;
 static const std::string DATA_COARSEN_TYPE = "CUBIC_COARSEN";
@@ -99,20 +105,20 @@ static const bool CONSISTENT_TYPE_2_BDRY = false;
 double convertToThs(double Thn);
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 
-VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(const std::string& object_name,
-                                                                         const Pointer<Database> input_db,
-                                                                         const std::string& default_options_prefix)
+VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(
+    const std::string& object_name,
+    const Pointer<Database> input_db,
+    const std::string& default_options_prefix)
     : FACPreconditionerStrategy(object_name)
 {
-
     // Create variables and register them with the variable database.
     VariableDatabase<NDIM>* var_db = VariableDatabase<NDIM>::getDatabase();
     Pointer<VariableContext> d_ctx = var_db->getContext("context");
 
     // State scratch variables: Velocity and pressure.
-    Pointer<SideVariable<NDIM, double> > un_scr_var = new SideVariable<NDIM, double>("un_scr");
-    Pointer<SideVariable<NDIM, double> > us_scr_var = new SideVariable<NDIM, double>("us_scr");
-    Pointer<CellVariable<NDIM, double> > p_scr_var = new CellVariable<NDIM, double>("p_scr");
+    Pointer<SideVariable<NDIM, double>> un_scr_var = new SideVariable<NDIM, double>("un_scr");
+    Pointer<SideVariable<NDIM, double>> us_scr_var = new SideVariable<NDIM, double>("us_scr");
+    Pointer<CellVariable<NDIM, double>> p_scr_var = new CellVariable<NDIM, double>("p_scr");
 
     // Register patch data indices
     const int un_scr_idx = var_db->registerVariableAndContext(un_scr_var, d_ctx, IntVector<NDIM>(1));
@@ -120,8 +126,8 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::VCTwoFluidStaggeredStokesBoxR
     const int p_scr_idx = var_db->registerVariableAndContext(p_scr_var, d_ctx, IntVector<NDIM>(1));
 
     // Setup Timers.
-    IBTK_DO_ONCE(t_smooth_error =
-                     TimerManager::getManager()->getTimer("IBTK::VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError()");
+    IBTK_DO_ONCE(t_smooth_error = TimerManager::getManager()->getTimer(
+                     "IBTK::VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError()");
                  t_solve_coarsest_level = TimerManager::getManager()->getTimer(
                      "IBTK::VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::solveCoarsestLevel()");
                  t_compute_residual = TimerManager::getManager()->getTimer(
@@ -131,7 +137,6 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::VCTwoFluidStaggeredStokesBoxR
 
 VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::~VCTwoFluidStaggeredStokesBoxRelaxationFACOperator()
 {
-
     return;
 }
 
@@ -146,10 +151,9 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::setThnIdx(int thn_idx)
 
 void
 VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::restrictResidual(const SAMRAIVectorReal<NDIM, double>& source,
-                                                                SAMRAIVectorReal<NDIM, double>& dest,
-                                                                int dest_level_num)
+                                                                    SAMRAIVectorReal<NDIM, double>& dest,
+                                                                    int dest_level_num)
 {
-
     return;
 }
 
@@ -158,33 +162,30 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::prolongError(const SAMRAIVect
                                                                 SAMRAIVectorReal<NDIM, double>& dest,
                                                                 int dest_level_num)
 {
-
     return;
 }
-
 
 void
 VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::prolongErrorAndCorrect(const SAMRAIVectorReal<NDIM, double>& source,
                                                                           SAMRAIVectorReal<NDIM, double>& dest,
                                                                           int dest_level_num)
 {
-
     return;
 }
 
-
 void
-VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<NDIM, double>& error, // Solution
-                                                 const SAMRAIVectorReal<NDIM, double>& residual,      // RHS - A*error on the entire patch level
-                                                 int level_num,
-                                                 int num_sweeps,
-                                                 bool /*performing_pre_sweeps*/,
-                                                 bool /*performing_post_sweeps*/)
+VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(
+    SAMRAIVectorReal<NDIM, double>& error,          // Solution
+    const SAMRAIVectorReal<NDIM, double>& residual, // RHS - A*error on the entire patch level
+    int level_num,
+    int num_sweeps,
+    bool /*performing_pre_sweeps*/,
+    bool /*performing_post_sweeps*/)
 {
     if (num_sweeps == 0) return;
 
     IBTK_TIMER_START(t_smooth_error);
-    
+
     // Get the vector components. These pull out patch data indices
     const int un_idx = error.getComponentDescriptorIndex(0); // network velocity, Un
     const int us_idx = error.getComponentDescriptorIndex(1); // solvent velocity, Us
@@ -193,13 +194,13 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<
     const int f_un_idx = residual.getComponentDescriptorIndex(0); // RHS_Un
     const int f_us_idx = residual.getComponentDescriptorIndex(1); // RHS_Us
     const int f_P_idx = residual.getComponentDescriptorIndex(2);  // RHS_pressure
-    
+
     // Create scratch indices
     // Copy values from the residual at step 0 into scratch indices
     // We want to solve for Un, Us and P at step k+1 using data from step k
     // Allocate data on all patches. (better to do this in InitializeSolverState)
     // d_hierarchy = error.getPatchHierarchy();
-    Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(level_num);
+    Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(level_num);
     level->allocatePatchData(un_scr_idx, 0.0);
     level->allocatePatchData(us_scr_idx, 0.0);
     level->allocatePatchData(p_scr_idx, 0.0);
@@ -249,44 +250,46 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<
     const double eta_s = 1.0;
     const double xi = 1.0;
     const double nu_n = 1.0;
-    const double nu_s = 1.0; 
+    const double nu_s = 1.0;
     // outer for loop for number of sweeps
-    for(int sweep = 0; sweep <= num_sweeps; sweep++){    
+    for (int sweep = 0; sweep <= num_sweeps; sweep++)
+    {
         // loop through all patches on this level
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
             const double* const dx = pgeom->getDx(); // dx[0] -> x, dx[1] -> y
-            const double* const xlow = pgeom->getXLower(); // {xlow[0], xlow[1]} -> physical location of bottom left of box.
+            const double* const xlow =
+                pgeom->getXLower(); // {xlow[0], xlow[1]} -> physical location of bottom left of box.
             const hier::Index<NDIM>& idx_low = patch->getBox().lower();
-            Pointer<CellData<NDIM, double> > thn_data = patch->getPatchData(thn_idx);
-            Pointer<SideData<NDIM, double> > un_data = patch->getPatchData(un_idx);
-            Pointer<SideData<NDIM, double> > us_data = patch->getPatchData(us_idx);
-            Pointer<CellData<NDIM, double> > p_data = patch->getPatchData(P_idx);
-            Pointer<SideData<NDIM, double> > un_scr_data = patch->getPatchData(un_scr_idx);
-            Pointer<SideData<NDIM, double> > us_scr_data = patch->getPatchData(us_scr_idx);
-            Pointer<CellData<NDIM, double> > p_scr_data = patch->getPatchData(p_scr_idx);
-            Pointer<SideData<NDIM, double> > f_un_data = patch->getPatchData(f_un_idx);
-            Pointer<SideData<NDIM, double> > f_us_data = patch->getPatchData(f_us_idx);
-            Pointer<CellData<NDIM, double> > f_p_data = patch->getPatchData(f_P_idx);
+            Pointer<CellData<NDIM, double>> thn_data = patch->getPatchData(thn_idx);
+            Pointer<SideData<NDIM, double>> un_data = patch->getPatchData(un_idx);
+            Pointer<SideData<NDIM, double>> us_data = patch->getPatchData(us_idx);
+            Pointer<CellData<NDIM, double>> p_data = patch->getPatchData(P_idx);
+            Pointer<SideData<NDIM, double>> un_scr_data = patch->getPatchData(un_scr_idx);
+            Pointer<SideData<NDIM, double>> us_scr_data = patch->getPatchData(us_scr_idx);
+            Pointer<CellData<NDIM, double>> p_scr_data = patch->getPatchData(p_scr_idx);
+            Pointer<SideData<NDIM, double>> f_un_data = patch->getPatchData(f_un_idx);
+            Pointer<SideData<NDIM, double>> f_us_data = patch->getPatchData(f_us_idx);
+            Pointer<CellData<NDIM, double>> f_p_data = patch->getPatchData(f_P_idx);
             IntVector<NDIM> xp(1, 0), yp(0, 1);
-            //un_scr_data->fillAll(*un_data); 
-            //us_scr_data->fillAll(*us_data);
-            //p_scr_data->fillAll(*p_data);
+            // un_scr_data->fillAll(*un_data);
+            // us_scr_data->fillAll(*us_data);
+            // p_scr_data->fillAll(*p_data);
 
-            MatrixXd A_box(9,9);       // 9 x 9 Matrix
-            VectorXd b;           // 9 x 1 RHS vector 
-            VectorXd sol;           // 9 x 1 solution vector
+            MatrixXd A_box(9, 9); // 9 x 9 Matrix
+            VectorXd b;           // 9 x 1 RHS vector
+            VectorXd sol;         // 9 x 1 solution vector
 
             for (CellIterator<NDIM> ci(patch->getBox()); ci; ci++) // cell-centers
             {
-                un_scr_data->fillAll(un_data); 
+                un_scr_data->fillAll(un_data);
                 us_scr_data->fillAll(us_data);
                 p_scr_data->fillAll(p_data);
 
-                const CellIndex<NDIM>& idx = ci();   // (i,j)
-                VectorNd x; // <- Eigen3 vector
+                const CellIndex<NDIM>& idx = ci(); // (i,j)
+                VectorNd x;                        // <- Eigen3 vector
                 for (int d = 0; d < NDIM; ++d)
                     x[d] = xlow[d] + dx[d] * (idx(d) - idx_low(d) + 0.5); // Get's physical location of idx.
 
@@ -302,142 +305,214 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<
                 double thn_upper_y = 0.5 * ((*thn_data)(idx) + (*thn_data)(idx + yp)); // thn(i,j+1/2)
 
                 // thn at corners
-                double thn_imhalf_jphalf = 0.25 * ((*thn_data)(idx-xp) + (*thn_data)(idx) + (*thn_data)(idx+yp) +
-                        (*thn_data)(idx-xp+yp)); // thn(i-1/2,j+1/2)
-                double thn_imhalf_jmhalf = 0.25 * ((*thn_data)(idx) + (*thn_data)(idx-xp) + (*thn_data)(idx-yp) +
-                        (*thn_data)(idx-xp-yp)); // thn(i-1/2,j-1/2)
-                double thn_iphalf_jphalf = 0.25 * ((*thn_data)(idx+xp) + (*thn_data)(idx) + (*thn_data)(idx+yp) +
-                        (*thn_data)(idx+xp+yp)); // thn(i+1/2,j+1/2)
-                double thn_iphalf_jmhalf = 0.25 * ((*thn_data)(idx+xp) + (*thn_data)(idx) + (*thn_data)(idx-yp) +
-                        (*thn_data)(idx+xp-yp)); // thn(i+1/2,j-1/2)
+                double thn_imhalf_jphalf = 0.25 * ((*thn_data)(idx - xp) + (*thn_data)(idx) + (*thn_data)(idx + yp) +
+                                                   (*thn_data)(idx - xp + yp)); // thn(i-1/2,j+1/2)
+                double thn_imhalf_jmhalf = 0.25 * ((*thn_data)(idx) + (*thn_data)(idx - xp) + (*thn_data)(idx - yp) +
+                                                   (*thn_data)(idx - xp - yp)); // thn(i-1/2,j-1/2)
+                double thn_iphalf_jphalf = 0.25 * ((*thn_data)(idx + xp) + (*thn_data)(idx) + (*thn_data)(idx + yp) +
+                                                   (*thn_data)(idx + xp + yp)); // thn(i+1/2,j+1/2)
+                double thn_iphalf_jmhalf = 0.25 * ((*thn_data)(idx + xp) + (*thn_data)(idx) + (*thn_data)(idx - yp) +
+                                                   (*thn_data)(idx + xp - yp)); // thn(i+1/2,j-1/2)
 
                 // network at west edge
-                A_box(0,0) = eta_n / (dx[0] * dx[0])*(-(*thn_data)(idx)-(*thn_data)(idx-xp)) - eta_n/(dx[1]*dx[1])*(thn_imhalf_jmhalf+thn_imhalf_jphalf)
-                                - xi/nu_n * thn_lower_x * convertToThs(thn_lower_x);
-                A_box(0,1) = eta_n / (dx[0] * dx[0])*((*thn_data)(idx));
-                A_box(0,2) = eta_n / (dx[0] * dx[1])*((*thn_data)(idx)-thn_imhalf_jmhalf);
-                A_box(0,3) = eta_n / (dx[0] * dx[1])*(thn_imhalf_jphalf-(*thn_data)(idx));
-                A_box(0,4) = xi/nu_n * thn_lower_x * convertToThs(thn_lower_x);
-                A_box(0,5) = A_box(0,6) = A_box(0,7) = 0.0;
-                A_box(0,8) = -thn_lower_x/dx[0];
+                A_box(0, 0) = eta_n / (dx[0] * dx[0]) * (-(*thn_data)(idx) - (*thn_data)(idx - xp)) -
+                              eta_n / (dx[1] * dx[1]) * (thn_imhalf_jmhalf + thn_imhalf_jphalf) -
+                              xi / nu_n * thn_lower_x * convertToThs(thn_lower_x);
+                A_box(0, 1) = eta_n / (dx[0] * dx[0]) * ((*thn_data)(idx));
+                A_box(0, 2) = eta_n / (dx[0] * dx[1]) * ((*thn_data)(idx)-thn_imhalf_jmhalf);
+                A_box(0, 3) = eta_n / (dx[0] * dx[1]) * (thn_imhalf_jphalf - (*thn_data)(idx));
+                A_box(0, 4) = xi / nu_n * thn_lower_x * convertToThs(thn_lower_x);
+                A_box(0, 5) = A_box(0, 6) = A_box(0, 7) = 0.0;
+                A_box(0, 8) = -thn_lower_x / dx[0];
 
-                A_box(4,4) = eta_s / (dx[0] * dx[0])*(-convertToThs((*thn_data)(idx))-convertToThs((*thn_data)(idx-xp))) - eta_s/(dx[1]*dx[1])*(convertToThs(thn_imhalf_jmhalf)
-                            + convertToThs(thn_imhalf_jphalf)) - xi/nu_n * thn_lower_x * convertToThs(thn_lower_x);
-                A_box(4,5) = eta_s / (dx[0] * dx[0])*(convertToThs((*thn_data)(idx)));
-                A_box(4,6) = eta_s / (dx[0] * dx[1])*(convertToThs((*thn_data)(idx))-convertToThs(thn_imhalf_jmhalf));
-                A_box(4,7) = eta_s / (dx[0] * dx[1])*(convertToThs(thn_imhalf_jphalf)-convertToThs((*thn_data)(idx)));
-                A_box(4,0) = xi/nu_s * thn_lower_x * convertToThs(thn_lower_x);
-                A_box(4,1) = A_box(4,2) = A_box(4,3) = 0.0;
-                A_box(4,8) = -convertToThs(thn_lower_x)/dx[0];
+                A_box(4, 4) =
+                    eta_s / (dx[0] * dx[0]) * (-convertToThs((*thn_data)(idx)) - convertToThs((*thn_data)(idx - xp))) -
+                    eta_s / (dx[1] * dx[1]) * (convertToThs(thn_imhalf_jmhalf) + convertToThs(thn_imhalf_jphalf)) -
+                    xi / nu_n * thn_lower_x * convertToThs(thn_lower_x);
+                A_box(4, 5) = eta_s / (dx[0] * dx[0]) * (convertToThs((*thn_data)(idx)));
+                A_box(4, 6) =
+                    eta_s / (dx[0] * dx[1]) * (convertToThs((*thn_data)(idx)) - convertToThs(thn_imhalf_jmhalf));
+                A_box(4, 7) =
+                    eta_s / (dx[0] * dx[1]) * (convertToThs(thn_imhalf_jphalf) - convertToThs((*thn_data)(idx)));
+                A_box(4, 0) = xi / nu_s * thn_lower_x * convertToThs(thn_lower_x);
+                A_box(4, 1) = A_box(4, 2) = A_box(4, 3) = 0.0;
+                A_box(4, 8) = -convertToThs(thn_lower_x) / dx[0];
 
                 // network at east edge
-                A_box(1,0) = eta_n / (dx[0] * dx[0])*(*thn_data)(idx);
-                A_box(1,1) = eta_n / (dx[0] * dx[0])*(-(*thn_data)(idx+xp)-(*thn_data)(idx)) - eta_n / (dx[1]*dx[1])*(thn_iphalf_jphalf+thn_iphalf_jmhalf)
-                            - xi/nu_n * thn_upper_x * convertToThs(thn_upper_x);
-                A_box(1,2) = eta_n / (dx[1] * dx[0])*(thn_iphalf_jmhalf-(*thn_data)(idx));
-                A_box(1,3) = eta_n / (dx[1] * dx[0])*((*thn_data)(idx)-thn_iphalf_jphalf);
-                A_box(1,4) = A_box(1,6) = A_box(1,7) = 0.0;
-                A_box(1,5) = xi/nu_n * thn_upper_x * convertToThs(thn_upper_x);
-                A_box(1,8) = thn_upper_x/dx[0];
+                A_box(1, 0) = eta_n / (dx[0] * dx[0]) * (*thn_data)(idx);
+                A_box(1, 1) = eta_n / (dx[0] * dx[0]) * (-(*thn_data)(idx + xp) - (*thn_data)(idx)) -
+                              eta_n / (dx[1] * dx[1]) * (thn_iphalf_jphalf + thn_iphalf_jmhalf) -
+                              xi / nu_n * thn_upper_x * convertToThs(thn_upper_x);
+                A_box(1, 2) = eta_n / (dx[1] * dx[0]) * (thn_iphalf_jmhalf - (*thn_data)(idx));
+                A_box(1, 3) = eta_n / (dx[1] * dx[0]) * ((*thn_data)(idx)-thn_iphalf_jphalf);
+                A_box(1, 4) = A_box(1, 6) = A_box(1, 7) = 0.0;
+                A_box(1, 5) = xi / nu_n * thn_upper_x * convertToThs(thn_upper_x);
+                A_box(1, 8) = thn_upper_x / dx[0];
 
-                A_box(5,4) = eta_s / (dx[0] * dx[0])*convertToThs((*thn_data)(idx));
-                A_box(5,5) = eta_s / (dx[0] * dx[0])*(-convertToThs((*thn_data)(idx+xp))-convertToThs((*thn_data)(idx)))
-                            - eta_s / (dx[1]*dx[1])* (convertToThs(thn_iphalf_jphalf) + convertToThs(thn_iphalf_jmhalf)) - xi/nu_s * thn_upper_x * convertToThs(thn_upper_x);
-                A_box(5,6) = eta_n / (dx[1] * dx[0])*(convertToThs(thn_iphalf_jmhalf)-convertToThs((*thn_data)(idx)));
-                A_box(5,7) = eta_n / (dx[1] * dx[0])*(convertToThs((*thn_data)(idx))-convertToThs(thn_iphalf_jphalf));
-                A_box(5,0) = A_box(5,2) = A_box(5,3) = 0.0;
-                A_box(5,1) = xi/nu_s * thn_upper_x * convertToThs(thn_upper_x);
-                A_box(5,8) = convertToThs(thn_upper_x)/dx[0];
+                A_box(5, 4) = eta_s / (dx[0] * dx[0]) * convertToThs((*thn_data)(idx));
+                A_box(5, 5) =
+                    eta_s / (dx[0] * dx[0]) * (-convertToThs((*thn_data)(idx + xp)) - convertToThs((*thn_data)(idx))) -
+                    eta_s / (dx[1] * dx[1]) * (convertToThs(thn_iphalf_jphalf) + convertToThs(thn_iphalf_jmhalf)) -
+                    xi / nu_s * thn_upper_x * convertToThs(thn_upper_x);
+                A_box(5, 6) =
+                    eta_n / (dx[1] * dx[0]) * (convertToThs(thn_iphalf_jmhalf) - convertToThs((*thn_data)(idx)));
+                A_box(5, 7) =
+                    eta_n / (dx[1] * dx[0]) * (convertToThs((*thn_data)(idx)) - convertToThs(thn_iphalf_jphalf));
+                A_box(5, 0) = A_box(5, 2) = A_box(5, 3) = 0.0;
+                A_box(5, 1) = xi / nu_s * thn_upper_x * convertToThs(thn_upper_x);
+                A_box(5, 8) = convertToThs(thn_upper_x) / dx[0];
 
                 // network at south edge
-                A_box(2,0) = eta_n / (dx[0] * dx[1])*((*thn_data)(idx)-thn_imhalf_jmhalf);
-                A_box(2,1) = eta_n / (dx[0] * dx[1])*(thn_iphalf_jmhalf-(*thn_data)(idx));
-                A_box(2,2) = eta_n / (dx[1] * dx[1])*(-(*thn_data)(idx)-(*thn_data)(idx-yp)) - eta_n/(dx[0]*dx[0])*(thn_iphalf_jmhalf+thn_imhalf_jmhalf)
-                            -xi / nu_n*thn_lower_y*convertToThs(thn_lower_y);
-                A_box(2,3) = eta_n / (dx[1] * dx[1])*((*thn_data)(idx));
-                A_box(2,4) = A_box(2,5) = A_box(2,7) = 0.0;
-                A_box(2,6) = xi/nu_n * thn_lower_y * convertToThs(thn_lower_y);
-                A_box(2,8) = -thn_lower_y/ dx[1];
+                A_box(2, 0) = eta_n / (dx[0] * dx[1]) * ((*thn_data)(idx)-thn_imhalf_jmhalf);
+                A_box(2, 1) = eta_n / (dx[0] * dx[1]) * (thn_iphalf_jmhalf - (*thn_data)(idx));
+                A_box(2, 2) = eta_n / (dx[1] * dx[1]) * (-(*thn_data)(idx) - (*thn_data)(idx - yp)) -
+                              eta_n / (dx[0] * dx[0]) * (thn_iphalf_jmhalf + thn_imhalf_jmhalf) -
+                              xi / nu_n * thn_lower_y * convertToThs(thn_lower_y);
+                A_box(2, 3) = eta_n / (dx[1] * dx[1]) * ((*thn_data)(idx));
+                A_box(2, 4) = A_box(2, 5) = A_box(2, 7) = 0.0;
+                A_box(2, 6) = xi / nu_n * thn_lower_y * convertToThs(thn_lower_y);
+                A_box(2, 8) = -thn_lower_y / dx[1];
 
-                A_box(6,4) = eta_s / (dx[0] * dx[1])*(convertToThs((*thn_data)(idx))-convertToThs(thn_imhalf_jmhalf));
-                A_box(6,5) = eta_s / (dx[0] * dx[1])*(convertToThs(thn_iphalf_jmhalf)-convertToThs((*thn_data)(idx)));
-                A_box(6,6) = eta_s / (dx[1] * dx[1])*(-convertToThs((*thn_data)(idx))-convertToThs((*thn_data)(idx-yp)))
-                            - eta_s / (dx[0] * dx[0])*(convertToThs(thn_iphalf_jmhalf)+convertToThs(thn_imhalf_jmhalf))- xi/nu_n*thn_lower_y*convertToThs(thn_lower_y);
-                A_box(6,7) = eta_s / (dx[1] * dx[1])*(convertToThs((*thn_data)(idx)));
-                A_box(6,0) = A_box(6,1) = A_box(6,3) = 0.0;
-                A_box(6,2) = xi/nu_s * thn_lower_y * convertToThs(thn_lower_y);
-                A_box(6,8) = -convertToThs(thn_lower_y)/ dx[1];
+                A_box(6, 4) =
+                    eta_s / (dx[0] * dx[1]) * (convertToThs((*thn_data)(idx)) - convertToThs(thn_imhalf_jmhalf));
+                A_box(6, 5) =
+                    eta_s / (dx[0] * dx[1]) * (convertToThs(thn_iphalf_jmhalf) - convertToThs((*thn_data)(idx)));
+                A_box(6, 6) =
+                    eta_s / (dx[1] * dx[1]) * (-convertToThs((*thn_data)(idx)) - convertToThs((*thn_data)(idx - yp))) -
+                    eta_s / (dx[0] * dx[0]) * (convertToThs(thn_iphalf_jmhalf) + convertToThs(thn_imhalf_jmhalf)) -
+                    xi / nu_n * thn_lower_y * convertToThs(thn_lower_y);
+                A_box(6, 7) = eta_s / (dx[1] * dx[1]) * (convertToThs((*thn_data)(idx)));
+                A_box(6, 0) = A_box(6, 1) = A_box(6, 3) = 0.0;
+                A_box(6, 2) = xi / nu_s * thn_lower_y * convertToThs(thn_lower_y);
+                A_box(6, 8) = -convertToThs(thn_lower_y) / dx[1];
 
                 // network at north edge
-                A_box(3,0) = eta_n / (dx[0] * dx[1])*(thn_imhalf_jphalf-(*thn_data)(idx));
-                A_box(3,1) = eta_n / (dx[0] * dx[1])*((*thn_data)(idx)-thn_iphalf_jphalf);
-                A_box(3,2) = eta_n / (dx[1] * dx[1])*((*thn_data)(idx));
-                A_box(3,3) = eta_n / (dx[1] * dx[1])*(-(*thn_data)(idx)-(*thn_data)(idx+yp)) - eta_n / (dx[0] * dx[0])*(thn_iphalf_jphalf-thn_imhalf_jphalf)
-                            -xi/nu_n*thn_upper_y*convertToThs(thn_upper_y);
-                A_box(3,4) = A_box(3,5) = A_box(3,6) = 0.0;
-                A_box(3,7) = xi/nu_n * thn_upper_y * convertToThs(thn_upper_y);
-                A_box(3,8) = thn_upper_y/ dx[1];
+                A_box(3, 0) = eta_n / (dx[0] * dx[1]) * (thn_imhalf_jphalf - (*thn_data)(idx));
+                A_box(3, 1) = eta_n / (dx[0] * dx[1]) * ((*thn_data)(idx)-thn_iphalf_jphalf);
+                A_box(3, 2) = eta_n / (dx[1] * dx[1]) * ((*thn_data)(idx));
+                A_box(3, 3) = eta_n / (dx[1] * dx[1]) * (-(*thn_data)(idx) - (*thn_data)(idx + yp)) -
+                              eta_n / (dx[0] * dx[0]) * (thn_iphalf_jphalf - thn_imhalf_jphalf) -
+                              xi / nu_n * thn_upper_y * convertToThs(thn_upper_y);
+                A_box(3, 4) = A_box(3, 5) = A_box(3, 6) = 0.0;
+                A_box(3, 7) = xi / nu_n * thn_upper_y * convertToThs(thn_upper_y);
+                A_box(3, 8) = thn_upper_y / dx[1];
 
-                A_box(7,4) = eta_s / (dx[0] * dx[1])*(convertToThs(thn_imhalf_jphalf)-convertToThs((*thn_data)(idx)));
-                A_box(7,5) = eta_s / (dx[0] * dx[1])*(convertToThs((*thn_data)(idx))-convertToThs(thn_iphalf_jphalf));
-                A_box(7,6) = eta_s / (dx[1] * dx[1])*(convertToThs((*thn_data)(idx)));
-                A_box(7,7) = eta_s / (dx[1] * dx[1])*(-convertToThs((*thn_data)(idx))-convertToThs((*thn_data)(idx+yp)))
-                            -  eta_s / (dx[0] * dx[0])*(convertToThs(thn_iphalf_jphalf)-convertToThs(thn_imhalf_jphalf))-xi / nu_s*thn_upper_y*convertToThs(thn_upper_y);
-                A_box(7,0) = A_box(7,1) = A_box(7,2) = 0.0;
-                A_box(7,3) = xi/nu_s * thn_upper_y * convertToThs(thn_upper_y);
-                A_box(7,8) = convertToThs(thn_upper_y)/ dx[1];
+                A_box(7, 4) =
+                    eta_s / (dx[0] * dx[1]) * (convertToThs(thn_imhalf_jphalf) - convertToThs((*thn_data)(idx)));
+                A_box(7, 5) =
+                    eta_s / (dx[0] * dx[1]) * (convertToThs((*thn_data)(idx)) - convertToThs(thn_iphalf_jphalf));
+                A_box(7, 6) = eta_s / (dx[1] * dx[1]) * (convertToThs((*thn_data)(idx)));
+                A_box(7, 7) =
+                    eta_s / (dx[1] * dx[1]) * (-convertToThs((*thn_data)(idx)) - convertToThs((*thn_data)(idx + yp))) -
+                    eta_s / (dx[0] * dx[0]) * (convertToThs(thn_iphalf_jphalf) - convertToThs(thn_imhalf_jphalf)) -
+                    xi / nu_s * thn_upper_y * convertToThs(thn_upper_y);
+                A_box(7, 0) = A_box(7, 1) = A_box(7, 2) = 0.0;
+                A_box(7, 3) = xi / nu_s * thn_upper_y * convertToThs(thn_upper_y);
+                A_box(7, 8) = convertToThs(thn_upper_y) / dx[1];
 
                 // incompressible constrain term at center
-                A_box(8,0) = thn_lower_x / dx[0];
-                A_box(8,1) = -thn_upper_x / dx[0];
-                A_box(8,2) = thn_lower_y / dx[1];
-                A_box(8,3) = -thn_upper_y / dx[1];
-                A_box(8,4) = convertToThs(thn_lower_x) / dx[0];
-                A_box(8,5) = -convertToThs(thn_upper_x) / dx[0];
-                A_box(8,6) = convertToThs(thn_lower_y) / dx[1];
-                A_box(8,7) = -convertToThs(thn_upper_y) / dx[1];
-                A_box(8,8) = 0.0;
+                A_box(8, 0) = thn_lower_x / dx[0];
+                A_box(8, 1) = -thn_upper_x / dx[0];
+                A_box(8, 2) = thn_lower_y / dx[1];
+                A_box(8, 3) = -thn_upper_y / dx[1];
+                A_box(8, 4) = convertToThs(thn_lower_x) / dx[0];
+                A_box(8, 5) = -convertToThs(thn_upper_x) / dx[0];
+                A_box(8, 6) = convertToThs(thn_lower_y) / dx[1];
+                A_box(8, 7) = -convertToThs(thn_upper_y) / dx[1];
+                A_box(8, 8) = 0.0;
 
                 // set-up RHS vector (include terms from residual (f_un,f_us,f_p))
-                // should be populated with the values from the previous iteration 
+                // should be populated with the values from the previous iteration
 
                 // network at west edge
-                b(0) = (*f_un_data)(lower_x_idx)-thn_lower_x/dx[0]*(*p_scr_data)(idx-xp) - eta_n/(dx[0]*dx[0])*(*thn_data)(idx-xp)*(*un_scr_data)(lower_x_idx-xp) + eta_n/(dx[1]*dx[1])*thn_imhalf_jphalf*(*un_scr_data)(lower_x_idx+yp)-eta_n/(dx[1]*dx[1])*thn_imhalf_jmhalf*(*un_scr_data)(lower_x_idx-yp)
-                    + eta_n/(dx[0]*dx[1])*thn_imhalf_jphalf*(*un_scr_data)(upper_y_idx-xp) - eta_n/(dx[0]*dx[1])*thn_imhalf_jmhalf*(*un_scr_data)(lower_y_idx-xp) - eta_n/(dx[0]*dx[1])*(*thn_data)(idx-xp)*((*un_scr_data)(upper_y_idx-xp) -(*un_scr_data)(lower_y_idx-xp));
-                
-                 // solvent at west edge
-                b(4) = (*f_us_data)(lower_x_idx)-convertToThs(thn_lower_x)/dx[0]*(*p_scr_data)(idx-xp) - eta_s/(dx[0]*dx[0])*convertToThs((*thn_data)(idx-xp))*(*us_scr_data)(lower_x_idx-xp) + eta_s/(dx[1]*dx[1])*convertToThs(thn_imhalf_jphalf)*(*us_scr_data)(lower_x_idx+yp)-eta_s/(dx[1]*dx[1])*convertToThs(thn_imhalf_jmhalf)*(*us_scr_data)(lower_x_idx-yp)
-                    + eta_s/(dx[0]*dx[1])*convertToThs(thn_imhalf_jphalf)*(*us_scr_data)(upper_y_idx-xp) - eta_s/(dx[0]*dx[1])*convertToThs(thn_imhalf_jmhalf)*(*us_scr_data)(lower_y_idx-xp) - eta_s/(dx[0]*dx[1])*convertToThs((*thn_data)(idx-xp))*((*us_scr_data)(upper_y_idx-xp) -(*us_scr_data)(lower_y_idx-xp));
+                b(0) = (*f_un_data)(lower_x_idx)-thn_lower_x / dx[0] * (*p_scr_data)(idx - xp) -
+                       eta_n / (dx[0] * dx[0]) * (*thn_data)(idx - xp) * (*un_scr_data)(lower_x_idx - xp) +
+                       eta_n / (dx[1] * dx[1]) * thn_imhalf_jphalf * (*un_scr_data)(lower_x_idx + yp) -
+                       eta_n / (dx[1] * dx[1]) * thn_imhalf_jmhalf * (*un_scr_data)(lower_x_idx - yp) +
+                       eta_n / (dx[0] * dx[1]) * thn_imhalf_jphalf * (*un_scr_data)(upper_y_idx - xp) -
+                       eta_n / (dx[0] * dx[1]) * thn_imhalf_jmhalf * (*un_scr_data)(lower_y_idx - xp) -
+                       eta_n / (dx[0] * dx[1]) * (*thn_data)(idx - xp) *
+                           ((*un_scr_data)(upper_y_idx - xp) - (*un_scr_data)(lower_y_idx - xp));
+
+                // solvent at west edge
+                b(4) =
+                    (*f_us_data)(lower_x_idx)-convertToThs(thn_lower_x) / dx[0] * (*p_scr_data)(idx - xp) -
+                    eta_s / (dx[0] * dx[0]) * convertToThs((*thn_data)(idx - xp)) * (*us_scr_data)(lower_x_idx - xp) +
+                    eta_s / (dx[1] * dx[1]) * convertToThs(thn_imhalf_jphalf) * (*us_scr_data)(lower_x_idx + yp) -
+                    eta_s / (dx[1] * dx[1]) * convertToThs(thn_imhalf_jmhalf) * (*us_scr_data)(lower_x_idx - yp) +
+                    eta_s / (dx[0] * dx[1]) * convertToThs(thn_imhalf_jphalf) * (*us_scr_data)(upper_y_idx - xp) -
+                    eta_s / (dx[0] * dx[1]) * convertToThs(thn_imhalf_jmhalf) * (*us_scr_data)(lower_y_idx - xp) -
+                    eta_s / (dx[0] * dx[1]) * convertToThs((*thn_data)(idx - xp)) *
+                        ((*us_scr_data)(upper_y_idx - xp) - (*us_scr_data)(lower_y_idx - xp));
 
                 // network at east edge
-                b(1) = (*f_un_data)(upper_x_idx)+thn_upper_x/dx[0]*(*p_scr_data)(idx+xp) - eta_n/(dx[0]*dx[0])*(*thn_data)(idx+xp)*(*un_scr_data)(upper_x_idx+xp)-eta_n/(dx[1]*dx[1])*thn_iphalf_jphalf*(*un_scr_data)(upper_x_idx+yp) - eta_n/(dx[1]*dx[1])*thn_iphalf_jmhalf*(*un_scr_data)(upper_x_idx-yp)
-                - eta_n/(dx[0]*dx[1])*thn_iphalf_jphalf*(*un_scr_data)(upper_y_idx+xp) + eta_n/(dx[0]*dx[1])*thn_iphalf_jmhalf*(*un_scr_data)(lower_y_idx+xp) + eta_n/(dx[0]*dx[1])*(*thn_data)(idx+xp)*((*un_scr_data)(upper_y_idx+xp) -(*un_scr_data)(lower_y_idx+xp));
+                b(1) = (*f_un_data)(upper_x_idx) + thn_upper_x / dx[0] * (*p_scr_data)(idx + xp) -
+                       eta_n / (dx[0] * dx[0]) * (*thn_data)(idx + xp) * (*un_scr_data)(upper_x_idx + xp) -
+                       eta_n / (dx[1] * dx[1]) * thn_iphalf_jphalf * (*un_scr_data)(upper_x_idx + yp) -
+                       eta_n / (dx[1] * dx[1]) * thn_iphalf_jmhalf * (*un_scr_data)(upper_x_idx - yp) -
+                       eta_n / (dx[0] * dx[1]) * thn_iphalf_jphalf * (*un_scr_data)(upper_y_idx + xp) +
+                       eta_n / (dx[0] * dx[1]) * thn_iphalf_jmhalf * (*un_scr_data)(lower_y_idx + xp) +
+                       eta_n / (dx[0] * dx[1]) * (*thn_data)(idx + xp) *
+                           ((*un_scr_data)(upper_y_idx + xp) - (*un_scr_data)(lower_y_idx + xp));
 
                 // solvent at east edge
-                b(5) = (*f_us_data)(upper_x_idx)+convertToThs(thn_upper_x)/dx[0]*(*p_scr_data)(idx+xp) - eta_s/(dx[0]*dx[0])*convertToThs((*thn_data)(idx+xp))*(*us_scr_data)(upper_x_idx+xp)-eta_s/(dx[1]*dx[1])*convertToThs(thn_iphalf_jphalf)*(*us_scr_data)(upper_x_idx+yp) - eta_s/(dx[1]*dx[1])*convertToThs(thn_iphalf_jmhalf)*(*us_scr_data)(upper_x_idx-yp)
-                - eta_s/(dx[0]*dx[1])*convertToThs(thn_iphalf_jphalf)*(*us_scr_data)(upper_y_idx+xp) + eta_s/(dx[0]*dx[1])*convertToThs(thn_iphalf_jmhalf)*(*us_scr_data)(lower_y_idx+xp) + eta_s/(dx[0]*dx[1])*convertToThs((*thn_data)(idx+xp))*((*us_scr_data)(upper_y_idx+xp) -(*us_scr_data)(lower_y_idx+xp)); 
+                b(5) =
+                    (*f_us_data)(upper_x_idx) + convertToThs(thn_upper_x) / dx[0] * (*p_scr_data)(idx + xp) -
+                    eta_s / (dx[0] * dx[0]) * convertToThs((*thn_data)(idx + xp)) * (*us_scr_data)(upper_x_idx + xp) -
+                    eta_s / (dx[1] * dx[1]) * convertToThs(thn_iphalf_jphalf) * (*us_scr_data)(upper_x_idx + yp) -
+                    eta_s / (dx[1] * dx[1]) * convertToThs(thn_iphalf_jmhalf) * (*us_scr_data)(upper_x_idx - yp) -
+                    eta_s / (dx[0] * dx[1]) * convertToThs(thn_iphalf_jphalf) * (*us_scr_data)(upper_y_idx + xp) +
+                    eta_s / (dx[0] * dx[1]) * convertToThs(thn_iphalf_jmhalf) * (*us_scr_data)(lower_y_idx + xp) +
+                    eta_s / (dx[0] * dx[1]) * convertToThs((*thn_data)(idx + xp)) *
+                        ((*us_scr_data)(upper_y_idx + xp) - (*us_scr_data)(lower_y_idx + xp));
 
                 // network at south edge
-                b(2) = (*f_un_data)(lower_y_idx)-thn_lower_y/dx[1]*(*p_scr_data)(idx-yp)-eta_n/(dx[1]*dx[1])*(*thn_data)(idx-yp)*(*un_scr_data)(lower_y_idx-yp) - eta_n/(dx[0]*dx[0])*thn_iphalf_jmhalf*(*un_scr_data)(lower_y_idx+xp)-eta_n/(dx[0]*dx[0])*thn_imhalf_jmhalf*(*un_scr_data)(lower_y_idx-xp)
-                + eta_n/(dx[0]*dx[1])*thn_iphalf_jmhalf*(*un_scr_data)(upper_x_idx-yp) - eta_n/(dx[0]*dx[1])*thn_imhalf_jmhalf*(*un_scr_data)(lower_x_idx-yp) - eta_n/(dx[0]*dx[1])*(*thn_data)(idx-yp)*((*un_scr_data)(upper_x_idx-yp)-(*un_scr_data)(lower_x_idx-yp));
+                b(2) = (*f_un_data)(lower_y_idx)-thn_lower_y / dx[1] * (*p_scr_data)(idx - yp) -
+                       eta_n / (dx[1] * dx[1]) * (*thn_data)(idx - yp) * (*un_scr_data)(lower_y_idx - yp) -
+                       eta_n / (dx[0] * dx[0]) * thn_iphalf_jmhalf * (*un_scr_data)(lower_y_idx + xp) -
+                       eta_n / (dx[0] * dx[0]) * thn_imhalf_jmhalf * (*un_scr_data)(lower_y_idx - xp) +
+                       eta_n / (dx[0] * dx[1]) * thn_iphalf_jmhalf * (*un_scr_data)(upper_x_idx - yp) -
+                       eta_n / (dx[0] * dx[1]) * thn_imhalf_jmhalf * (*un_scr_data)(lower_x_idx - yp) -
+                       eta_n / (dx[0] * dx[1]) * (*thn_data)(idx - yp) *
+                           ((*un_scr_data)(upper_x_idx - yp) - (*un_scr_data)(lower_x_idx - yp));
 
                 // solvent at south edge
-                b(6) = (*f_us_data)(lower_y_idx)-convertToThs(thn_lower_y)/dx[1]*(*p_scr_data)(idx-yp)-eta_s/(dx[1]*dx[1])*convertToThs((*thn_data)(idx-yp))*(*us_scr_data)(lower_y_idx-yp) - eta_s/(dx[0]*dx[0])*convertToThs(thn_iphalf_jmhalf)*(*us_scr_data)(lower_y_idx+xp)-eta_s/(dx[0]*dx[0])*convertToThs(thn_imhalf_jmhalf)*(*us_scr_data)(lower_y_idx-xp)
-                + eta_s/(dx[0]*dx[1])*convertToThs(thn_iphalf_jmhalf)*(*us_scr_data)(upper_x_idx-yp) - eta_s/(dx[0]*dx[1])*convertToThs(thn_imhalf_jmhalf)*(*us_scr_data)(lower_x_idx-yp) - eta_s/(dx[0]*dx[1])*convertToThs((*thn_data)(idx-yp))*((*us_scr_data)(upper_x_idx-yp)-(*us_scr_data)(lower_x_idx-yp));
+                b(6) =
+                    (*f_us_data)(lower_y_idx)-convertToThs(thn_lower_y) / dx[1] * (*p_scr_data)(idx - yp) -
+                    eta_s / (dx[1] * dx[1]) * convertToThs((*thn_data)(idx - yp)) * (*us_scr_data)(lower_y_idx - yp) -
+                    eta_s / (dx[0] * dx[0]) * convertToThs(thn_iphalf_jmhalf) * (*us_scr_data)(lower_y_idx + xp) -
+                    eta_s / (dx[0] * dx[0]) * convertToThs(thn_imhalf_jmhalf) * (*us_scr_data)(lower_y_idx - xp) +
+                    eta_s / (dx[0] * dx[1]) * convertToThs(thn_iphalf_jmhalf) * (*us_scr_data)(upper_x_idx - yp) -
+                    eta_s / (dx[0] * dx[1]) * convertToThs(thn_imhalf_jmhalf) * (*us_scr_data)(lower_x_idx - yp) -
+                    eta_s / (dx[0] * dx[1]) * convertToThs((*thn_data)(idx - yp)) *
+                        ((*us_scr_data)(upper_x_idx - yp) - (*us_scr_data)(lower_x_idx - yp));
 
                 // network at north edge
-                b(3) = (*f_un_data)(upper_y_idx)+thn_upper_y/dx[1]*(*p_scr_data)(idx+yp)-eta_n/(dx[1]*dx[1])*(*thn_data)(idx+yp)*(*un_scr_data)(upper_y_idx+yp) - eta_n/(dx[0]*dx[0])*thn_iphalf_jphalf*(*un_scr_data)(upper_y_idx+xp)-eta_n/(dx[0]*dx[0])*thn_imhalf_jphalf*(*un_scr_data)(upper_y_idx-xp)
-                - eta_n/(dx[0]*dx[1])*thn_iphalf_jphalf*(*un_scr_data)(upper_x_idx+yp) + eta_n/(dx[0]*dx[1])*thn_imhalf_jphalf*(*un_scr_data)(lower_x_idx+yp) + eta_n/(dx[0]*dx[1])*(*thn_data)(idx+yp)*((*un_scr_data)(upper_x_idx+yp)-(*un_scr_data)(lower_x_idx+yp));
+                b(3) = (*f_un_data)(upper_y_idx) + thn_upper_y / dx[1] * (*p_scr_data)(idx + yp) -
+                       eta_n / (dx[1] * dx[1]) * (*thn_data)(idx + yp) * (*un_scr_data)(upper_y_idx + yp) -
+                       eta_n / (dx[0] * dx[0]) * thn_iphalf_jphalf * (*un_scr_data)(upper_y_idx + xp) -
+                       eta_n / (dx[0] * dx[0]) * thn_imhalf_jphalf * (*un_scr_data)(upper_y_idx - xp) -
+                       eta_n / (dx[0] * dx[1]) * thn_iphalf_jphalf * (*un_scr_data)(upper_x_idx + yp) +
+                       eta_n / (dx[0] * dx[1]) * thn_imhalf_jphalf * (*un_scr_data)(lower_x_idx + yp) +
+                       eta_n / (dx[0] * dx[1]) * (*thn_data)(idx + yp) *
+                           ((*un_scr_data)(upper_x_idx + yp) - (*un_scr_data)(lower_x_idx + yp));
 
                 // solvent at north edge
-                b(7) = (*f_us_data)(upper_y_idx)+convertToThs(thn_upper_y)/dx[1]*(*p_scr_data)(idx+yp)-eta_s/(dx[1]*dx[1])*convertToThs((*thn_data)(idx+yp))*(*us_scr_data)(upper_y_idx+yp) - eta_s/(dx[0]*dx[0])*convertToThs(thn_iphalf_jphalf)*(*us_scr_data)(upper_y_idx+xp)-eta_s/(dx[0]*dx[0])*convertToThs(thn_imhalf_jphalf)*(*us_scr_data)(upper_y_idx-xp)
-                - eta_s/(dx[0]*dx[1])*convertToThs(thn_iphalf_jphalf)*(*us_scr_data)(upper_x_idx+yp) + eta_s/(dx[0]*dx[1])*convertToThs(thn_imhalf_jphalf)*(*us_scr_data)(lower_x_idx+yp) + eta_s/(dx[0]*dx[1])*convertToThs((*thn_data)(idx+yp))*((*us_scr_data)(upper_x_idx+yp)-(*us_scr_data)(lower_x_idx+yp));
+                b(7) =
+                    (*f_us_data)(upper_y_idx) + convertToThs(thn_upper_y) / dx[1] * (*p_scr_data)(idx + yp) -
+                    eta_s / (dx[1] * dx[1]) * convertToThs((*thn_data)(idx + yp)) * (*us_scr_data)(upper_y_idx + yp) -
+                    eta_s / (dx[0] * dx[0]) * convertToThs(thn_iphalf_jphalf) * (*us_scr_data)(upper_y_idx + xp) -
+                    eta_s / (dx[0] * dx[0]) * convertToThs(thn_imhalf_jphalf) * (*us_scr_data)(upper_y_idx - xp) -
+                    eta_s / (dx[0] * dx[1]) * convertToThs(thn_iphalf_jphalf) * (*us_scr_data)(upper_x_idx + yp) +
+                    eta_s / (dx[0] * dx[1]) * convertToThs(thn_imhalf_jphalf) * (*us_scr_data)(lower_x_idx + yp) +
+                    eta_s / (dx[0] * dx[1]) * convertToThs((*thn_data)(idx + yp)) *
+                        ((*us_scr_data)(upper_x_idx + yp) - (*us_scr_data)(lower_x_idx + yp));
 
                 // pressure at cell center
                 b(8) = (*f_p_data)(idx);
 
-                sol = A_box.lu().solve(b); // solve Ax = b per cell 
-                // sol = A_box.partialPivLu().solve(b); 
+                sol = A_box.lu().solve(b); // solve Ax = b per cell
+                // sol = A_box.partialPivLu().solve(b);
                 (*un_data)(lower_x_idx) = sol(0);
                 (*un_data)(upper_x_idx) = sol(1);
                 (*un_data)(lower_y_idx) = sol(2);
@@ -449,27 +524,26 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(SAMRAIVectorReal<
                 (*p_data)(idx) = sol(8);
 
             } // cell centers
-        } // patches
-    } // num_sweeps
+        }     // patches
+    }         // num_sweeps
     IBTK_TIMER_STOP(t_smooth_error);
     return;
 }
 
 bool
 VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::solveCoarsestLevel(SAMRAIVectorReal<NDIM, double>& error,
-                                                        const SAMRAIVectorReal<NDIM, double>& residual,
-                                                        int coarsest_ln)
+                                                                      const SAMRAIVectorReal<NDIM, double>& residual,
+                                                                      int coarsest_ln)
 {
-    
     return false;
 }
 
 void
 VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorReal<NDIM, double>& residual,
-                                                     const SAMRAIVectorReal<NDIM, double>& solution,
-                                                     const SAMRAIVectorReal<NDIM, double>& rhs,
-                                                     int coarsest_level_num,
-                                                     int finest_level_num)
+                                                                   const SAMRAIVectorReal<NDIM, double>& solution,
+                                                                   const SAMRAIVectorReal<NDIM, double>& rhs,
+                                                                   int coarsest_level_num,
+                                                                   int finest_level_num)
 {
     IBTK_TIMER_START(t_compute_residual);
 
@@ -477,12 +551,12 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
     const int un_idx = solution.getComponentDescriptorIndex(0); // network velocity, Un
     const int us_idx = solution.getComponentDescriptorIndex(1); // solvent velocity, Us
     const int P_idx = solution.getComponentDescriptorIndex(2);  // pressure
-    const int rhs_un_idx = rhs.getComponentDescriptorIndex(0); // RHS Un
-    const int rhs_us_idx = rhs.getComponentDescriptorIndex(1); // RHS Us
-    const int rhs_P_idx = rhs.getComponentDescriptorIndex(2); // RHS P
-    const int res_un_idx = residual.getComponentDescriptorIndex(0); 
-    const int res_us_idx = residual.getComponentDescriptorIndex(1); 
-    const int res_P_idx = residual.getComponentDescriptorIndex(2); 
+    const int rhs_un_idx = rhs.getComponentDescriptorIndex(0);  // RHS Un
+    const int rhs_us_idx = rhs.getComponentDescriptorIndex(1);  // RHS Us
+    const int rhs_P_idx = rhs.getComponentDescriptorIndex(2);   // RHS P
+    const int res_un_idx = residual.getComponentDescriptorIndex(0);
+    const int res_us_idx = residual.getComponentDescriptorIndex(1);
+    const int res_P_idx = residual.getComponentDescriptorIndex(2);
     const int thn_idx = d_thn_idx;
 
     // Simultaneously fill ghost cell values for all components.
@@ -529,29 +603,32 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
     const double eta_s = 1.0;
     const double xi = 1.0;
     const double nu_n = 1.0;
-    const double nu_s = 1.0; 
+    const double nu_s = 1.0;
 
     for (int ln = coarsest_level_num; ln <= finest_level_num; ++ln)
     {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
             const double* const dx = pgeom->getDx(); // dx[0] -> x, dx[1] -> y
             const double* const xlow =
                 pgeom->getXLower(); // {xlow[0], xlow[1]} -> physical location of bottom left of box.
             const hier::Index<NDIM>& idx_low = patch->getBox().lower();
-            Pointer<CellData<NDIM, double> > p_data = patch->getPatchData(P_idx);
-            Pointer<CellData<NDIM, double> > rhs_P_data = patch->getPatchData(rhs_P_idx); // result of applying operator (eqn 3)
-            Pointer<CellData<NDIM, double> > thn_data = patch->getPatchData(thn_idx);
-            Pointer<SideData<NDIM, double> > un_data = patch->getPatchData(un_idx);
-            Pointer<SideData<NDIM, double> > rhs_un_data = patch->getPatchData(rhs_un_idx); // result of applying operator (eqn 1)
-            Pointer<SideData<NDIM, double> > us_data = patch->getPatchData(us_idx);
-            Pointer<SideData<NDIM, double> > rhs_us_data = patch->getPatchData(rhs_us_idx); // result of applying operator (eqn 2)
-            Pointer<SideData<NDIM, double> > res_un_data = patch->getPatchData(res_un_idx);   
-            Pointer<SideData<NDIM, double> > res_us_data = patch->getPatchData(res_un_idx);  
-            Pointer<CellData<NDIM, double> > res_P_data = patch->getPatchData(res_P_idx);   
+            Pointer<CellData<NDIM, double>> p_data = patch->getPatchData(P_idx);
+            Pointer<CellData<NDIM, double>> rhs_P_data =
+                patch->getPatchData(rhs_P_idx); // result of applying operator (eqn 3)
+            Pointer<CellData<NDIM, double>> thn_data = patch->getPatchData(thn_idx);
+            Pointer<SideData<NDIM, double>> un_data = patch->getPatchData(un_idx);
+            Pointer<SideData<NDIM, double>> rhs_un_data =
+                patch->getPatchData(rhs_un_idx); // result of applying operator (eqn 1)
+            Pointer<SideData<NDIM, double>> us_data = patch->getPatchData(us_idx);
+            Pointer<SideData<NDIM, double>> rhs_us_data =
+                patch->getPatchData(rhs_us_idx); // result of applying operator (eqn 2)
+            Pointer<SideData<NDIM, double>> res_un_data = patch->getPatchData(res_un_idx);
+            Pointer<SideData<NDIM, double>> res_us_data = patch->getPatchData(res_un_idx);
+            Pointer<CellData<NDIM, double>> res_P_data = patch->getPatchData(res_P_idx);
             IntVector<NDIM> xp(1, 0), yp(0, 1);
 
             for (CellIterator<NDIM> ci(patch->getBox()); ci; ci++) // cell-centers
@@ -571,15 +648,21 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
                 double thn_upper_x = 0.5 * ((*thn_data)(idx) + (*thn_data)(idx + xp)); // thn(i+1/2,j)
                 double thn_lower_y = 0.5 * ((*thn_data)(idx) + (*thn_data)(idx - yp)); // thn(i,j-1/2)
                 double thn_upper_y = 0.5 * ((*thn_data)(idx) + (*thn_data)(idx + yp)); // thn(i,j+1/2)
-            
+
                 // conservation of mass
-                
-                double div_un_dot_thn_dx = ((thn_upper_x * (*un_data)(upper_x_idx))-(thn_lower_x * (*un_data)(lower_x_idx))) / dx[0];
-                double div_un_dot_thn_dy = ((thn_upper_y * (*un_data)(upper_y_idx))-(thn_lower_y * (*un_data)(lower_y_idx))) / dx[1];
+
+                double div_un_dot_thn_dx =
+                    ((thn_upper_x * (*un_data)(upper_x_idx)) - (thn_lower_x * (*un_data)(lower_x_idx))) / dx[0];
+                double div_un_dot_thn_dy =
+                    ((thn_upper_y * (*un_data)(upper_y_idx)) - (thn_lower_y * (*un_data)(lower_y_idx))) / dx[1];
                 double div_un_thn = div_un_dot_thn_dx + div_un_dot_thn_dy;
 
-                double div_us_dot_ths_dx =((convertToThs(thn_upper_x) * (*us_data)(upper_x_idx))-(convertToThs(thn_lower_x) * (*us_data)(lower_x_idx))) / dx[0];
-                double div_us_dot_ths_dy = ((convertToThs(thn_upper_y) * (*us_data)(upper_y_idx))-(convertToThs(thn_lower_y) * (*us_data)(lower_y_idx))) /dx[1];
+                double div_us_dot_ths_dx = ((convertToThs(thn_upper_x) * (*us_data)(upper_x_idx)) -
+                                            (convertToThs(thn_lower_x) * (*us_data)(lower_x_idx))) /
+                                           dx[0];
+                double div_us_dot_ths_dy = ((convertToThs(thn_upper_y) * (*us_data)(upper_y_idx)) -
+                                            (convertToThs(thn_lower_y) * (*us_data)(lower_y_idx))) /
+                                           dx[1];
                 double div_us_ths = div_us_dot_ths_dx + div_us_dot_ths_dy;
                 (*res_P_data)(idx) = (*rhs_P_data)(idx) - (div_un_thn + div_us_ths);
             }
@@ -587,18 +670,18 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
             for (SideIterator<NDIM> si(patch->getBox(), 0); si; si++) // side-centers in x-dir
             {
                 const SideIndex<NDIM>& idx = si(); // axis = 0, (i-1/2,j)
-                //pout << "\n At idx " << idx << " \n ";
+                // pout << "\n At idx " << idx << " \n ";
 
-                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i-1,j)   
-                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)     
+                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i-1,j)
+                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)
                 SideIndex<NDIM> lower_y_idx(idx_c_up, 1, 0); // (i,j-1/2)
                 SideIndex<NDIM> upper_y_idx(idx_c_up, 1, 1); // (i,j+1/2)
                 SideIndex<NDIM> l_y_idx(idx_c_low, 1, 0);    // (i-1,j-1/2)
                 SideIndex<NDIM> u_y_idx(idx_c_low, 1, 1);    // (i-1,j+1/2)
 
                 // thn at sides
-                double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up));     // thn(i-1/2,j)
-                //pout << "thn_lower is " << thn_lower << "\n";
+                double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up)); // thn(i-1/2,j)
+                // pout << "thn_lower is " << thn_lower << "\n";
                 // thn at corners
                 double thn_imhalf_jphalf =
                     0.25 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_low) + (*thn_data)(idx_c_up + yp) +
@@ -610,7 +693,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
                 // components of first row (x-component of network vel) of network equation
                 double ddx_Thn_dx_un = eta_n / (dx[0] * dx[0]) *
                                        ((*thn_data)(idx_c_up) * ((*un_data)(idx + xp) - (*un_data)(idx)) -
-                                        (*thn_data)(idx_c_low) * ((*un_data)(idx) - (*un_data)(idx - xp)));               
+                                        (*thn_data)(idx_c_low) * ((*un_data)(idx) - (*un_data)(idx - xp)));
                 double ddy_Thn_dy_un = eta_n / (dx[1] * dx[1]) *
                                        (thn_imhalf_jphalf * ((*un_data)(idx + yp) - (*un_data)(idx)) -
                                         thn_imhalf_jmhalf * ((*un_data)(idx) - (*un_data)(idx - yp)));
@@ -623,17 +706,17 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
 
                 double drag_n = -xi / nu_n * thn_lower * convertToThs(thn_lower) * ((*un_data)(idx) - (*us_data)(idx));
                 double pressure_n = -thn_lower / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*res_un_data)(idx) = (*rhs_un_data)(idx) - (ddx_Thn_dx_un + ddy_Thn_dy_un + ddy_Thn_dx_vn + ddx_Thn_dy_vn + drag_n + pressure_n);
+                (*res_un_data)(idx) = (*rhs_un_data)(idx) - (ddx_Thn_dx_un + ddy_Thn_dy_un + ddy_Thn_dx_vn +
+                                                             ddx_Thn_dy_vn + drag_n + pressure_n);
 
                 // solvent equation
                 double ddx_Ths_dx_us =
                     eta_s / (dx[0] * dx[0]) *
                     (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(idx + xp) - (*us_data)(idx)) -
                      convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(idx) - (*us_data)(idx - xp)));
-                double ddy_Ths_dy_us =
-                    eta_s / (dx[1] * dx[1]) *
-                    (convertToThs(thn_imhalf_jphalf) * ((*us_data)(idx + yp) - (*us_data)(idx)) -
-                     convertToThs(thn_imhalf_jmhalf) * ((*us_data)(idx) - (*us_data)(idx - yp)));
+                double ddy_Ths_dy_us = eta_s / (dx[1] * dx[1]) *
+                                       (convertToThs(thn_imhalf_jphalf) * ((*us_data)(idx + yp) - (*us_data)(idx)) -
+                                        convertToThs(thn_imhalf_jmhalf) * ((*us_data)(idx) - (*us_data)(idx - yp)));
                 double ddy_Ths_dx_vs =
                     eta_s / (dx[1] * dx[0]) *
                     (convertToThs(thn_imhalf_jphalf) * ((*us_data)(upper_y_idx) - (*us_data)(u_y_idx)) -
@@ -645,24 +728,25 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
 
                 double drag_s = -xi / nu_s * thn_lower * convertToThs(thn_lower) * ((*us_data)(idx) - (*un_data)(idx));
                 double pressure_s = -convertToThs(thn_lower) / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*res_us_data)(idx) = (*rhs_us_data)(idx) - (ddx_Ths_dx_us + ddy_Ths_dy_us + ddy_Ths_dx_vs + ddx_Ths_dy_vs + drag_s + pressure_s);
+                (*res_us_data)(idx) = (*rhs_us_data)(idx) - (ddx_Ths_dx_us + ddy_Ths_dy_us + ddy_Ths_dx_vs +
+                                                             ddx_Ths_dy_vs + drag_s + pressure_s);
             }
 
-            //pout << "\n\n Looping over y-dir side-centers \n\n";
+            // pout << "\n\n Looping over y-dir side-centers \n\n";
 
             for (SideIterator<NDIM> si(patch->getBox(), 1); si; si++) // side-centers in y-dir
             {
                 const SideIndex<NDIM>& idx = si(); // axis = 1, (i,j-1/2)
 
-                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i,j-1)  
-                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)  
+                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i,j-1)
+                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)
                 SideIndex<NDIM> lower_x_idx(idx_c_up, 0, 0); // (i-1/2,j)
                 SideIndex<NDIM> upper_x_idx(idx_c_up, 0, 1); // (i+1/2,j)
                 SideIndex<NDIM> l_x_idx(idx_c_low, 0, 0);    // (i-1/2,j-1)
                 SideIndex<NDIM> u_x_idx(idx_c_low, 0, 1);    // (i+1/2,j-1)
 
                 // thn at sides
-                double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up));     // thn(i,j-1/2)
+                double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up)); // thn(i,j-1/2)
 
                 // thn at corners
                 double thn_imhalf_jmhalf =
@@ -688,7 +772,8 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
 
                 double drag_n = -xi / nu_n * thn_lower * convertToThs(thn_lower) * ((*un_data)(idx) - (*us_data)(idx));
                 double pressure_n = -thn_lower / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*res_un_data)(idx) = (*rhs_un_data)(idx) - (ddy_Thn_dy_un + ddx_Thn_dx_un + ddx_Thn_dy_vn + ddy_Thn_dx_vn + drag_n + pressure_n);
+                (*res_un_data)(idx) = (*rhs_un_data)(idx) - (ddy_Thn_dy_un + ddx_Thn_dx_un + ddx_Thn_dy_vn +
+                                                             ddy_Thn_dx_vn + drag_n + pressure_n);
 
                 // Solvent equation
                 double ddy_Ths_dy_us =
@@ -709,7 +794,8 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
 
                 double drag_s = -xi / nu_s * thn_lower * convertToThs(thn_lower) * ((*us_data)(idx) - (*un_data)(idx));
                 double pressure_s = -convertToThs(thn_lower) / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*res_us_data)(idx) = (*rhs_us_data)(idx) - (ddy_Ths_dy_us + ddx_Ths_dx_us + ddx_Ths_dy_vs + ddy_Ths_dx_vs + drag_s + pressure_s);
+                (*res_us_data)(idx) = (*rhs_us_data)(idx) - (ddy_Ths_dy_us + ddx_Ths_dx_us + ddx_Ths_dy_vs +
+                                                             ddy_Ths_dx_vs + drag_s + pressure_s);
             }
         }
     }
@@ -730,22 +816,23 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::setToZero(SAMRAIVectorReal<ND
     const int un_idx = vec.getComponentDescriptorIndex(0); // network velocity, Un
     const int us_idx = vec.getComponentDescriptorIndex(1); // solvent velocity, Us
     const int P_idx = vec.getComponentDescriptorIndex(2);  // pressure
-    //d_level_data_ops[level_num]->setToScalar(un_idx, 0.0, /*interior_only*/ false);
-    //d_level_data_ops[level_num]->setToScalar(us_idx, 0.0, /*interior_only*/ false);
-    //d_level_data_ops[level_num]->setToScalar(p_idx, 0.0, /*interior_only*/ false);
+    // d_level_data_ops[level_num]->setToScalar(un_idx, 0.0, /*interior_only*/ false);
+    // d_level_data_ops[level_num]->setToScalar(us_idx, 0.0, /*interior_only*/ false);
+    // d_level_data_ops[level_num]->setToScalar(p_idx, 0.0, /*interior_only*/ false);
     return;
 } // setToZero
 
 void
-VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::initializeOperatorState(const SAMRAIVectorReal<NDIM, double>& solution,
-                                                                        const SAMRAIVectorReal<NDIM, double>& rhs)
+VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::initializeOperatorState(
+    const SAMRAIVectorReal<NDIM, double>& solution,
+    const SAMRAIVectorReal<NDIM, double>& rhs)
 {
     // Setup solution and rhs vectors.
-    Pointer<CellVariable<NDIM, double> > solution_var = solution.getComponentVariable(0);
-    Pointer<CellVariable<NDIM, double> > rhs_var = rhs.getComponentVariable(0);
+    Pointer<CellVariable<NDIM, double>> solution_var = solution.getComponentVariable(0);
+    Pointer<CellVariable<NDIM, double>> rhs_var = rhs.getComponentVariable(0);
 
-    Pointer<CellDataFactory<NDIM, double> > solution_pdat_fac = solution_var->getPatchDataFactory();
-    Pointer<CellDataFactory<NDIM, double> > rhs_pdat_fac = rhs_var->getPatchDataFactory();
+    Pointer<CellDataFactory<NDIM, double>> solution_pdat_fac = solution_var->getPatchDataFactory();
+    Pointer<CellDataFactory<NDIM, double>> rhs_pdat_fac = rhs_var->getPatchDataFactory();
     d_hierarchy = solution.getPatchHierarchy();
 
 #if !defined(NDEBUG)
@@ -761,13 +848,12 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::initializeOperatorState(const
 void
 VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::deallocateOperatorState()
 {
-
     return;
 }
 
 /////////////////////////////// PRIVATE //////////////////////////////////////
 
-////////////////////////////////////////////////////////////////////////////// 
+//////////////////////////////////////////////////////////////////////////////
 } // namespace IBTK
 
 //////////////////////////////////////////////////////////////////////////////

--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h
@@ -22,8 +22,8 @@
 
 #include "ibtk/CCPoissonSolverManager.h"
 #include "ibtk/FACPreconditionerStrategy.h"
-#include "ibtk/PoissonFACPreconditioner.h"
 #include "ibtk/HierarchyGhostCellInterpolation.h"
+#include "ibtk/PoissonFACPreconditioner.h"
 
 #include "IntVector.h"
 #include "PoissonSpecifications.h"
@@ -74,8 +74,8 @@ public:
      * \brief Constructor.
      */
     VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(const std::string& object_name,
-                                        SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db,
-                                        const std::string& default_options_prefix);
+                                                      SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db,
+                                                      const std::string& default_options_prefix);
 
     /*!
      * \brief Destructor.
@@ -86,13 +86,13 @@ public:
      * \name Functions for configuring the solver.
      */
     //\{
-    
+
     /*!
      * \brief Zero-out the provided vector on the specified level of the patch
      * hierarchy.
-     */  
+     */
     void setToZero(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& error, int level_num) override;
-   
+
     /*!
      * \brief Restrict the residual from the source vector to the destination
      * vector on the specified level of the patch hierarchy.
@@ -101,8 +101,8 @@ public:
      * the same vector.
      */
     void restrictResidual(const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& source,
-                                  SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& dest,
-                                  int dest_level_num) override;
+                          SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& dest,
+                          int dest_level_num) override;
 
     /*!
      * \brief Prolong the error from the source vector to the destination
@@ -112,8 +112,8 @@ public:
      * the same vector.
      */
     void prolongError(const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& source,
-                              SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& dest,
-                              int dest_level_num) override;
+                      SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& dest,
+                      int dest_level_num) override;
 
     /*!
      * \brief Prolong the error from the source vector to the destination vector
@@ -124,8 +124,8 @@ public:
      * the same vector.
      */
     void prolongErrorAndCorrect(const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& source,
-                                        SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& dest,
-                                        int dest_level_num) override;
+                                SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& dest,
+                                int dest_level_num) override;
 
     /*!
      * \name Implementation of FACPreconditionerStrategy interface.
@@ -182,11 +182,11 @@ public:
                          int finest_level_num) override;
 
     //\}
-     /*!
+    /*!
      * \brief Compute implementation-specific hierarchy-dependent data.
      */
     void initializeOperatorState(const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& solution,
-                                            const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& rhs) override;
+                                 const SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& rhs) override;
 
     /*!
      * \brief Remove implementation-specific hierarchy-dependent data.
@@ -194,10 +194,9 @@ public:
     void deallocateOperatorState() override;
 
 protected:
-   
     int d_thn_idx;
     int un_scr_idx, us_scr_idx, p_scr_idx;
-    
+
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> d_hierarchy; // Reference patch hierarchy
     std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_un_bc_coefs;
     std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_us_bc_coefs;
@@ -207,7 +206,7 @@ protected:
         d_P_fill_pattern;
     std::vector<IBTK::HierarchyGhostCellInterpolation::InterpolationTransactionComponent> transaction_comps;
     SAMRAI::tbox::Pointer<IBTK::HierarchyGhostCellInterpolation> d_hier_bdry_fill, d_no_fill;
-    
+
 private:
     /*!
      * \brief Default constructor.
@@ -223,7 +222,8 @@ private:
      *
      * \param from The value to copy to this object.
      */
-    VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(const VCTwoFluidStaggeredStokesBoxRelaxationFACOperator& from) = delete;
+    VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(const VCTwoFluidStaggeredStokesBoxRelaxationFACOperator& from) =
+        delete;
 
     /*!
      * \brief Assignment operator.
@@ -234,7 +234,8 @@ private:
      *
      * \return A reference to this object.
      */
-    VCTwoFluidStaggeredStokesBoxRelaxationFACOperator& operator=(const VCTwoFluidStaggeredStokesBoxRelaxationFACOperator& that) = delete;
+    VCTwoFluidStaggeredStokesBoxRelaxationFACOperator&
+    operator=(const VCTwoFluidStaggeredStokesBoxRelaxationFACOperator& that) = delete;
 
     /*
      * Level solvers and solver parameters.
@@ -242,7 +243,7 @@ private:
     std::string d_level_solver_type = CCPoissonSolverManager::PETSC_LEVEL_SOLVER, d_level_solver_default_options_prefix;
     double d_level_solver_abs_residual_tol = 1.0e-50, d_level_solver_rel_residual_tol = 1.0e-5;
     int d_level_solver_max_iterations = 1;
-    std::vector<SAMRAI::tbox::Pointer<PoissonSolver> > d_level_solvers;
+    std::vector<SAMRAI::tbox::Pointer<PoissonSolver>> d_level_solvers;
     SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> d_level_solver_db;
 
     /*
@@ -254,7 +255,7 @@ private:
     /*
      * Patch overlap data.
      */
-    std::vector<std::vector<SAMRAI::hier::BoxList<NDIM> > > d_patch_bc_box_overlap;
+    std::vector<std::vector<SAMRAI::hier::BoxList<NDIM>>> d_patch_bc_box_overlap;
 };
 } // namespace IBTK
 

--- a/VCTwoFluidStaggeredStokesOperator.cpp
+++ b/VCTwoFluidStaggeredStokesOperator.cpp
@@ -14,8 +14,8 @@
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
 #include "ibamr/StaggeredStokesPhysicalBoundaryHelper.h"
-#include "ibamr/VCTwoFluidStaggeredStokesOperator.h"
 #include "ibamr/ibamr_utilities.h"
+#include "ibamr/namespaces.h" // IWYU pragma: keep
 
 #include "ibtk/CellNoCornersFillPattern.h"
 #include "ibtk/HierarchyGhostCellInterpolation.h"
@@ -42,7 +42,8 @@
 #include <string>
 #include <vector>
 
-#include "ibamr/namespaces.h" // IWYU pragma: keep
+// Local includes
+#include "VCTwoFluidStaggeredStokesOperator.h"
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
@@ -58,10 +59,16 @@ static const int SIDEG = 1;
 
 // Types of refining and coarsening to perform prior to setting coarse-fine
 // boundary and physical boundary ghost cell values.
-static const std::string CC_DATA_REFINE_TYPE = "CONSERVATIVE_LINEAR_REFINE"; // how to fill in fine cells from coarse cells, how to fill ghost cells on refine patch
-static const std::string SC_DATA_REFINE_TYPE = "CONSERVATIVE_LINEAR_REFINE"; // how to fill in fine cells from coarse cells, how to fill ghost cells on refine patch
+static const std::string CC_DATA_REFINE_TYPE =
+    "CONSERVATIVE_LINEAR_REFINE"; // how to fill in fine cells from coarse cells, how to fill ghost cells on refine
+                                  // patch
+static const std::string SC_DATA_REFINE_TYPE =
+    "CONSERVATIVE_LINEAR_REFINE"; // how to fill in fine cells from coarse cells, how to fill ghost cells on refine
+                                  // patch
 static const bool USE_CF_INTERPOLATION = true;
-static const std::string DATA_COARSEN_TYPE = "CUBIC_COARSEN"; // going from fine to coarse. fill in coarse cells by whatever is in the fine cells. synchronizing the hierarchies
+static const std::string DATA_COARSEN_TYPE =
+    "CUBIC_COARSEN"; // going from fine to coarse. fill in coarse cells by whatever is in the fine cells. synchronizing
+                     // the hierarchies
 
 // Type of extrapolation to use at physical boundaries.
 static const std::string BDRY_EXTRAP_TYPE = "LINEAR"; // these operations are all in IBAMR
@@ -75,7 +82,6 @@ static Timer* t_apply;
 static Timer* t_initialize_operator_state;
 static Timer* t_deallocate_operator_state;
 } // namespace
-
 
 double convertToThs(double Thn);
 /////////////////////////////// PUBLIC ///////////////////////////////////////
@@ -236,12 +242,12 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
     const int us_scratch_idx = d_x->getComponentDescriptorIndex(1);
     const int thn_idx = d_thn_idx;
 
-    Pointer<SideVariable<NDIM, double> > un_sc_var = x.getComponentVariable(0);
-    Pointer<SideVariable<NDIM, double> > us_sc_var = x.getComponentVariable(1);
-    Pointer<CellVariable<NDIM, double> > P_cc_var = x.getComponentVariable(2);
-    Pointer<SideVariable<NDIM, double> > A_un_sc_var = y.getComponentVariable(0);
-    Pointer<SideVariable<NDIM, double> > A_us_sc_var = y.getComponentVariable(1);
-    Pointer<CellVariable<NDIM, double> > A_P_cc_var = y.getComponentVariable(2);
+    Pointer<SideVariable<NDIM, double>> un_sc_var = x.getComponentVariable(0);
+    Pointer<SideVariable<NDIM, double>> us_sc_var = x.getComponentVariable(1);
+    Pointer<CellVariable<NDIM, double>> P_cc_var = x.getComponentVariable(2);
+    Pointer<SideVariable<NDIM, double>> A_un_sc_var = y.getComponentVariable(0);
+    Pointer<SideVariable<NDIM, double>> A_us_sc_var = y.getComponentVariable(1);
+    Pointer<CellVariable<NDIM, double>> A_P_cc_var = y.getComponentVariable(2);
 
     // Simultaneously fill ghost cell values for all components.
     using InterpolationTransactionComponent = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
@@ -294,24 +300,24 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
 
     for (int ln = 0; ln <= d_hierarchy->getFinestLevelNumber(); ++ln)
     {
-        Pointer<PatchLevel<NDIM> > level = d_hierarchy->getPatchLevel(ln);
+        Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(ln);
         for (PatchLevel<NDIM>::Iterator p(level); p; p++)
         {
-            Pointer<Patch<NDIM> > patch = level->getPatch(p());
-            Pointer<CartesianPatchGeometry<NDIM> > pgeom = patch->getPatchGeometry();
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
             const double* const dx = pgeom->getDx(); // dx[0] -> x, dx[1] -> y
             const double* const xlow =
                 pgeom->getXLower(); // {xlow[0], xlow[1]} -> physical location of bottom left of box.
             const hier::Index<NDIM>& idx_low = patch->getBox().lower();
-            Pointer<CellData<NDIM, double> > p_data = patch->getPatchData(P_idx);
-            Pointer<CellData<NDIM, double> > A_P_data =
+            Pointer<CellData<NDIM, double>> p_data = patch->getPatchData(P_idx);
+            Pointer<CellData<NDIM, double>> A_P_data =
                 patch->getPatchData(A_P_idx); // result of applying operator (eqn 3)
-            Pointer<CellData<NDIM, double> > thn_data = patch->getPatchData(thn_idx);
-            Pointer<SideData<NDIM, double> > un_data = patch->getPatchData(un_idx);
-            Pointer<SideData<NDIM, double> > A_un_data =
+            Pointer<CellData<NDIM, double>> thn_data = patch->getPatchData(thn_idx);
+            Pointer<SideData<NDIM, double>> un_data = patch->getPatchData(un_idx);
+            Pointer<SideData<NDIM, double>> A_un_data =
                 patch->getPatchData(A_un_idx); // result of applying operator (eqn 1)
-            Pointer<SideData<NDIM, double> > us_data = patch->getPatchData(us_idx);
-            Pointer<SideData<NDIM, double> > A_us_data =
+            Pointer<SideData<NDIM, double>> us_data = patch->getPatchData(us_idx);
+            Pointer<SideData<NDIM, double>> A_us_data =
                 patch->getPatchData(A_us_idx); // result of applying operator (eqn 2)
             IntVector<NDIM> xp(1, 0), yp(0, 1);
 
@@ -332,15 +338,21 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double thn_upper_x = 0.5 * ((*thn_data)(idx) + (*thn_data)(idx + xp)); // thn(i+1/2,j)
                 double thn_lower_y = 0.5 * ((*thn_data)(idx) + (*thn_data)(idx - yp)); // thn(i,j-1/2)
                 double thn_upper_y = 0.5 * ((*thn_data)(idx) + (*thn_data)(idx + yp)); // thn(i,j+1/2)
-            
+
                 // conservation of mass
-                
-                double div_un_dot_thn_dx = ((thn_upper_x * (*un_data)(upper_x_idx))-(thn_lower_x * (*un_data)(lower_x_idx))) / dx[0];
-                double div_un_dot_thn_dy = ((thn_upper_y * (*un_data)(upper_y_idx))-(thn_lower_y * (*un_data)(lower_y_idx))) / dx[1];
+
+                double div_un_dot_thn_dx =
+                    ((thn_upper_x * (*un_data)(upper_x_idx)) - (thn_lower_x * (*un_data)(lower_x_idx))) / dx[0];
+                double div_un_dot_thn_dy =
+                    ((thn_upper_y * (*un_data)(upper_y_idx)) - (thn_lower_y * (*un_data)(lower_y_idx))) / dx[1];
                 double div_un_thn = div_un_dot_thn_dx + div_un_dot_thn_dy;
 
-                double div_us_dot_ths_dx =((convertToThs(thn_upper_x) * (*us_data)(upper_x_idx))-(convertToThs(thn_lower_x) * (*us_data)(lower_x_idx))) / dx[0];
-                double div_us_dot_ths_dy = ((convertToThs(thn_upper_y) * (*us_data)(upper_y_idx))-(convertToThs(thn_lower_y) * (*us_data)(lower_y_idx))) /dx[1];
+                double div_us_dot_ths_dx = ((convertToThs(thn_upper_x) * (*us_data)(upper_x_idx)) -
+                                            (convertToThs(thn_lower_x) * (*us_data)(lower_x_idx))) /
+                                           dx[0];
+                double div_us_dot_ths_dy = ((convertToThs(thn_upper_y) * (*us_data)(upper_y_idx)) -
+                                            (convertToThs(thn_lower_y) * (*us_data)(lower_y_idx))) /
+                                           dx[1];
                 double div_us_ths = div_us_dot_ths_dx + div_us_dot_ths_dy;
                 (*A_P_data)(idx) = div_un_thn + div_us_ths;
             }
@@ -348,18 +360,18 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
             for (SideIterator<NDIM> si(patch->getBox(), 0); si; si++) // side-centers in x-dir
             {
                 const SideIndex<NDIM>& idx = si(); // axis = 0, (i-1/2,j)
-                //pout << "\n At idx " << idx << " \n ";
+                // pout << "\n At idx " << idx << " \n ";
 
-                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i-1,j)   
-                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)     
+                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i-1,j)
+                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)
                 SideIndex<NDIM> lower_y_idx(idx_c_up, 1, 0); // (i,j-1/2)
                 SideIndex<NDIM> upper_y_idx(idx_c_up, 1, 1); // (i,j+1/2)
                 SideIndex<NDIM> l_y_idx(idx_c_low, 1, 0);    // (i-1,j-1/2)
                 SideIndex<NDIM> u_y_idx(idx_c_low, 1, 1);    // (i-1,j+1/2)
 
                 // thn at sides
-                double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up));     // thn(i-1/2,j)
-                //pout << "thn_lower is " << thn_lower << "\n";
+                double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up)); // thn(i-1/2,j)
+                // pout << "thn_lower is " << thn_lower << "\n";
                 // thn at corners
                 double thn_imhalf_jphalf =
                     0.25 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_low) + (*thn_data)(idx_c_up + yp) +
@@ -372,7 +384,7 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double ddx_Thn_dx_un = eta_n / (dx[0] * dx[0]) *
                                        ((*thn_data)(idx_c_up) * ((*un_data)(idx + xp) - (*un_data)(idx)) -
                                         (*thn_data)(idx_c_low) * ((*un_data)(idx) - (*un_data)(idx - xp)));
-               
+
                 double ddy_Thn_dy_un = eta_n / (dx[1] * dx[1]) *
                                        (thn_imhalf_jphalf * ((*un_data)(idx + yp) - (*un_data)(idx)) -
                                         thn_imhalf_jmhalf * ((*un_data)(idx) - (*un_data)(idx - yp)));
@@ -392,10 +404,9 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                     eta_s / (dx[0] * dx[0]) *
                     (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(idx + xp) - (*us_data)(idx)) -
                      convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(idx) - (*us_data)(idx - xp)));
-                double ddy_Ths_dy_us =
-                    eta_s / (dx[1] * dx[1]) *
-                    (convertToThs(thn_imhalf_jphalf) * ((*us_data)(idx + yp) - (*us_data)(idx)) -
-                     convertToThs(thn_imhalf_jmhalf) * ((*us_data)(idx) - (*us_data)(idx - yp)));
+                double ddy_Ths_dy_us = eta_s / (dx[1] * dx[1]) *
+                                       (convertToThs(thn_imhalf_jphalf) * ((*us_data)(idx + yp) - (*us_data)(idx)) -
+                                        convertToThs(thn_imhalf_jmhalf) * ((*us_data)(idx) - (*us_data)(idx - yp)));
                 double ddy_Ths_dx_vs =
                     eta_s / (dx[1] * dx[0]) *
                     (convertToThs(thn_imhalf_jphalf) * ((*us_data)(upper_y_idx) - (*us_data)(u_y_idx)) -
@@ -410,21 +421,21 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 (*A_us_data)(idx) = ddx_Ths_dx_us + ddy_Ths_dy_us + ddy_Ths_dx_vs + ddx_Ths_dy_vs + drag_s + pressure_s;
             }
 
-            //pout << "\n\n Looping over y-dir side-centers \n\n";
+            // pout << "\n\n Looping over y-dir side-centers \n\n";
 
             for (SideIterator<NDIM> si(patch->getBox(), 1); si; si++) // side-centers in y-dir
             {
                 const SideIndex<NDIM>& idx = si(); // axis = 1, (i,j-1/2)
 
-                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i,j-1)  
-                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)  
+                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i,j-1)
+                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)
                 SideIndex<NDIM> lower_x_idx(idx_c_up, 0, 0); // (i-1/2,j)
                 SideIndex<NDIM> upper_x_idx(idx_c_up, 0, 1); // (i+1/2,j)
                 SideIndex<NDIM> l_x_idx(idx_c_low, 0, 0);    // (i-1/2,j-1)
                 SideIndex<NDIM> u_x_idx(idx_c_low, 0, 1);    // (i+1/2,j-1)
 
                 // thn at sides
-                double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up));     // thn(i,j-1/2)
+                double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up)); // thn(i,j-1/2)
 
                 // thn at corners
                 double thn_imhalf_jmhalf =
@@ -500,7 +511,7 @@ VCTwoFluidStaggeredStokesOperator::initializeOperatorState(const SAMRAIVectorRea
     d_x = in.cloneVector(in.getName());
     d_b = out.cloneVector(out.getName());
 
-     // Setup operator state.
+    // Setup operator state.
     d_hierarchy = in.getPatchHierarchy();
 
     // Allocate scratch data.
@@ -538,7 +549,7 @@ VCTwoFluidStaggeredStokesOperator::initializeOperatorState(const SAMRAIVectorRea
                                                                BDRY_EXTRAP_TYPE,
                                                                CONSISTENT_TYPE_2_BDRY,
                                                                d_P_bc_coef,
-                                                               d_P_fill_pattern);  // noFillCorners
+                                                               d_P_fill_pattern); // noFillCorners
     d_transaction_comps[3] = InterpolationTransactionComponent(thn_idx,
                                                                CC_DATA_REFINE_TYPE,
                                                                USE_CF_INTERPOLATION,
@@ -620,8 +631,8 @@ VCTwoFluidStaggeredStokesOperator::modifyRhsForBcs(SAMRAIVectorReal<NDIM, double
     {
         // Set y := y - A*0, i.e., shift the right-hand-side vector to account for
         // inhomogeneous boundary conditions.
-        Pointer<SAMRAIVectorReal<NDIM, double> > x = y.cloneVector("");
-        Pointer<SAMRAIVectorReal<NDIM, double> > b = y.cloneVector("");
+        Pointer<SAMRAIVectorReal<NDIM, double>> x = y.cloneVector("");
+        Pointer<SAMRAIVectorReal<NDIM, double>> b = y.cloneVector("");
         x->allocateVectorData();
         b->allocateVectorData();
         x->setToScalar(0.0);
@@ -636,7 +647,7 @@ VCTwoFluidStaggeredStokesOperator::modifyRhsForBcs(SAMRAIVectorReal<NDIM, double
         }
         StaggeredStokesPhysicalBoundaryHelper::resetBcCoefObjects(d_un_bc_coefs, d_P_bc_coef);
         apply(*x, *b);
-        y.subtract(Pointer<SAMRAIVectorReal<NDIM, double> >(&y, false), b);
+        y.subtract(Pointer<SAMRAIVectorReal<NDIM, double>>(&y, false), b);
         x->freeVectorComponents();
         b->freeVectorComponents();
     }

--- a/apply.cpp
+++ b/apply.cpp
@@ -14,7 +14,7 @@
 #include <ibamr/PETScKrylovStaggeredStokesSolver.h>
 #include <ibamr/StaggeredStokesSolverManager.h>
 #include <ibamr/StokesSpecifications.h>
-#include <ibamr/VCTwoFluidStaggeredStokesOperator.h>
+#include <ibamr/app_namespaces.h>
 
 #include <ibtk/AppInitializer.h>
 #include <ibtk/IBTKInit.h>
@@ -30,7 +30,8 @@
 #include <SAMRAI_config.h>
 #include <StandardTagAndInitialize.h>
 
-#include <ibamr/app_namespaces.h>
+// Local includes
+#include "VCTwoFluidStaggeredStokesOperator.h"
 
 /*******************************************************************************
  * For each run, the input filename must be given on the command line.  In all *
@@ -54,15 +55,15 @@ main(int argc, char* argv[])
 
         // Create major algorithm and data objects that comprise the
         // application.  These objects are configured from the input database.
-        Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
+        Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
-        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
-        Pointer<StandardTagAndInitialize<NDIM> > error_detector = new StandardTagAndInitialize<NDIM>(
+        Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM>> error_detector = new StandardTagAndInitialize<NDIM>(
             "StandardTagAndInitialize", NULL, app_initializer->getComponentDatabase("StandardTagAndInitialize"));
-        Pointer<BergerRigoutsos<NDIM> > box_generator = new BergerRigoutsos<NDIM>();
-        Pointer<LoadBalancer<NDIM> > load_balancer =
+        Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM>> load_balancer =
             new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
-        Pointer<GriddingAlgorithm<NDIM> > gridding_algorithm =
+        Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
             new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
                                         app_initializer->getComponentDatabase("GriddingAlgorithm"),
                                         error_detector,
@@ -74,28 +75,29 @@ main(int argc, char* argv[])
         Pointer<VariableContext> ctx = var_db->getContext("context");
 
         // State variables: Velocity and pressure.
-        Pointer<SideVariable<NDIM, double> > un_sc_var = new SideVariable<NDIM, double>("un_sc");
-        Pointer<SideVariable<NDIM, double> > us_sc_var = new SideVariable<NDIM, double>("us_sc");
-        Pointer<CellVariable<NDIM, double> > p_cc_var = new CellVariable<NDIM, double>("p_cc");
+        Pointer<SideVariable<NDIM, double>> un_sc_var = new SideVariable<NDIM, double>("un_sc");
+        Pointer<SideVariable<NDIM, double>> us_sc_var = new SideVariable<NDIM, double>("us_sc");
+        Pointer<CellVariable<NDIM, double>> p_cc_var = new CellVariable<NDIM, double>("p_cc");
 
         // variable coefficient: theta_n
-        Pointer<CellVariable<NDIM, double> > thn_cc_var = new CellVariable<NDIM, double>("thn_cc");
+        Pointer<CellVariable<NDIM, double>> thn_cc_var = new CellVariable<NDIM, double>("thn_cc");
 
         // Results of operator "forces" and "divergence"
-        Pointer<SideVariable<NDIM, double> > f_un_sc_var = new SideVariable<NDIM, double>("f_un_sc");
-        Pointer<SideVariable<NDIM, double> > f_us_sc_var = new SideVariable<NDIM, double>("f_us_sc");
-        Pointer<CellVariable<NDIM, double> > f_cc_var = new CellVariable<NDIM, double>("f_cc");
+        Pointer<SideVariable<NDIM, double>> f_un_sc_var = new SideVariable<NDIM, double>("f_un_sc");
+        Pointer<SideVariable<NDIM, double>> f_us_sc_var = new SideVariable<NDIM, double>("f_us_sc");
+        Pointer<CellVariable<NDIM, double>> f_cc_var = new CellVariable<NDIM, double>("f_cc");
 
         // Error terms.
-        Pointer<SideVariable<NDIM, double> > e_un_sc_var = new SideVariable<NDIM, double>("e_un_sc");
-        Pointer<SideVariable<NDIM, double> > e_us_sc_var = new SideVariable<NDIM, double>("e_us_sc");
-        Pointer<CellVariable<NDIM, double> > e_cc_var = new CellVariable<NDIM, double>("e_cc");
+        Pointer<SideVariable<NDIM, double>> e_un_sc_var = new SideVariable<NDIM, double>("e_un_sc");
+        Pointer<SideVariable<NDIM, double>> e_us_sc_var = new SideVariable<NDIM, double>("e_us_sc");
+        Pointer<CellVariable<NDIM, double>> e_cc_var = new CellVariable<NDIM, double>("e_cc");
 
         // Register patch data indices...
         const int un_sc_idx = var_db->registerVariableAndContext(un_sc_var, ctx, IntVector<NDIM>(1));
         const int us_sc_idx = var_db->registerVariableAndContext(us_sc_var, ctx, IntVector<NDIM>(1));
         const int p_cc_idx = var_db->registerVariableAndContext(p_cc_var, ctx, IntVector<NDIM>(1));
-        const int thn_cc_idx = var_db->registerVariableAndContext(thn_cc_var, ctx, IntVector<NDIM>(1));  // 1 layer of ghost cells
+        const int thn_cc_idx =
+            var_db->registerVariableAndContext(thn_cc_var, ctx, IntVector<NDIM>(1)); // 1 layer of ghost cells
         const int f_cc_idx = var_db->registerVariableAndContext(f_cc_var, ctx, IntVector<NDIM>(1));
         const int f_un_sc_idx = var_db->registerVariableAndContext(f_un_sc_var, ctx, IntVector<NDIM>(1));
         const int f_us_sc_idx = var_db->registerVariableAndContext(f_us_sc_var, ctx, IntVector<NDIM>(1));
@@ -104,22 +106,22 @@ main(int argc, char* argv[])
         const int e_cc_idx = var_db->registerVariableAndContext(e_cc_var, ctx, IntVector<NDIM>(1));
 
         // Drawing variables
-        Pointer<CellVariable<NDIM, double> > draw_un_var = new CellVariable<NDIM, double>("draw_un", NDIM);
-        Pointer<CellVariable<NDIM, double> > draw_fn_var = new CellVariable<NDIM, double>("draw_fn", NDIM);
-        Pointer<CellVariable<NDIM, double> > draw_en_var = new CellVariable<NDIM, double>("draw_en", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_un_var = new CellVariable<NDIM, double>("draw_un", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_fn_var = new CellVariable<NDIM, double>("draw_fn", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_en_var = new CellVariable<NDIM, double>("draw_en", NDIM);
         const int draw_un_idx = var_db->registerVariableAndContext(draw_un_var, ctx);
         const int draw_fn_idx = var_db->registerVariableAndContext(draw_fn_var, ctx);
         const int draw_en_idx = var_db->registerVariableAndContext(draw_en_var, ctx);
 
-        Pointer<CellVariable<NDIM, double> > draw_us_var = new CellVariable<NDIM, double>("draw_us", NDIM);
-        Pointer<CellVariable<NDIM, double> > draw_fs_var = new CellVariable<NDIM, double>("draw_fs", NDIM);
-        Pointer<CellVariable<NDIM, double> > draw_es_var = new CellVariable<NDIM, double>("draw_es", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_us_var = new CellVariable<NDIM, double>("draw_us", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_fs_var = new CellVariable<NDIM, double>("draw_fs", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_es_var = new CellVariable<NDIM, double>("draw_es", NDIM);
         const int draw_us_idx = var_db->registerVariableAndContext(draw_us_var, ctx);
         const int draw_fs_idx = var_db->registerVariableAndContext(draw_fs_var, ctx);
         const int draw_es_idx = var_db->registerVariableAndContext(draw_es_var, ctx);
 
         // Register variables for plotting.
-        Pointer<VisItDataWriter<NDIM> > visit_data_writer = app_initializer->getVisItDataWriter();
+        Pointer<VisItDataWriter<NDIM>> visit_data_writer = app_initializer->getVisItDataWriter();
         TBOX_ASSERT(visit_data_writer);
 
         visit_data_writer->registerPlotQuantity("Pressure", "SCALAR", p_cc_idx);
@@ -177,7 +179,7 @@ main(int argc, char* argv[])
         // Allocate data on each level of the patch hierarchy.
         for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
         {
-            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
             level->allocatePatchData(un_sc_idx, 0.0);
             level->allocatePatchData(us_sc_idx, 0.0);
             level->allocatePatchData(f_un_sc_idx, 0.0);
@@ -260,8 +262,8 @@ main(int argc, char* argv[])
         stokes_op.apply(u_vec, f_vec);
 
         // Compute error and print error norms.
-        e_vec.subtract(Pointer<SAMRAIVectorReal<NDIM, double> >(&f_vec, false),  // numerical
-                       Pointer<SAMRAIVectorReal<NDIM, double> >(&e_vec, false)); // analytical
+        e_vec.subtract(Pointer<SAMRAIVectorReal<NDIM, double>>(&f_vec, false),  // numerical
+                       Pointer<SAMRAIVectorReal<NDIM, double>>(&e_vec, false)); // analytical
         pout << "|e|_oo = " << e_vec.maxNorm() << "\n";
         pout << "|e|_2  = " << e_vec.L2Norm() << "\n";
         pout << "|e|_1  = " << e_vec.L1Norm() << "\n";
@@ -272,7 +274,8 @@ main(int argc, char* argv[])
         const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
         const int wgt_sc_idx = hier_math_ops.getSideWeightPatchDescriptorIndex();
 
-        HierarchySideDataOpsReal<NDIM, double> hier_sc_data_ops(patch_hierarchy, 0, patch_hierarchy->getFinestLevelNumber());
+        HierarchySideDataOpsReal<NDIM, double> hier_sc_data_ops(
+            patch_hierarchy, 0, patch_hierarchy->getFinestLevelNumber());
         pout << "Error in un :\n"
              << "  L1-norm:  " << std::setprecision(10) << hier_sc_data_ops.L1Norm(e_un_sc_idx, wgt_sc_idx) << "\n"
              << "  L2-norm:  " << hier_sc_data_ops.L2Norm(e_un_sc_idx, wgt_sc_idx) << "\n"
@@ -283,14 +286,13 @@ main(int argc, char* argv[])
              << "  L2-norm:  " << hier_sc_data_ops.L2Norm(e_us_sc_idx, wgt_sc_idx) << "\n"
              << "  max-norm: " << hier_sc_data_ops.maxNorm(e_us_sc_idx, wgt_sc_idx) << "\n";
 
-  
-        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy, 0, patch_hierarchy->getFinestLevelNumber());
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(
+            patch_hierarchy, 0, patch_hierarchy->getFinestLevelNumber());
         pout << "Error in p :\n"
              << "  L1-norm:  " << hier_cc_data_ops.L1Norm(e_cc_idx, wgt_cc_idx) << "\n"
              << "  L2-norm:  " << hier_cc_data_ops.L2Norm(e_cc_idx, wgt_cc_idx) << "\n"
              << "  max-norm: " << hier_cc_data_ops.maxNorm(e_cc_idx, wgt_cc_idx) << "\n"
              << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
-
 
         // Interpolate the side-centered data to cell centers for output.
         static const bool synch_cf_interface = true;
@@ -308,7 +310,7 @@ main(int argc, char* argv[])
         // Allocate data on each level of the patch hierarchy.
         for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
         {
-            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
             level->deallocatePatchData(un_sc_idx);
             level->deallocatePatchData(us_sc_idx);
             level->deallocatePatchData(f_un_sc_idx);

--- a/solver.cpp
+++ b/solver.cpp
@@ -13,16 +13,18 @@
 
 #include <ibamr/StaggeredStokesSolverManager.h>
 #include <ibamr/StokesSpecifications.h>
-#include "VCTwoFluidStaggeredStokesOperator.h"
-#include <ibtk/LinearOperator.h>
+#include <ibamr/app_namespaces.h>
 
-#include <ibtk/AppInitializer.h>
-#include <ibtk/IBTKInit.h>
-#include <ibtk/muParserCartGridFunction.h>
-#include <ibtk/muParserRobinBcCoefs.h>
 #include "ibtk/CartCellDoubleQuadraticRefine.h"
 #include "ibtk/CartSideDoubleRT0Refine.h"
 #include "ibtk/PETScKrylovLinearSolver.h"
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/LinearOperator.h>
+#include <ibtk/muParserCartGridFunction.h>
+#include <ibtk/muParserRobinBcCoefs.h>
+
+#include "VCTwoFluidStaggeredStokesOperator.h"
 
 #include <petscsys.h>
 
@@ -32,8 +34,6 @@
 #include <LoadBalancer.h>
 #include <SAMRAI_config.h>
 #include <StandardTagAndInitialize.h>
-
-#include <ibamr/app_namespaces.h>
 
 /*******************************************************************************
  * For each run, the input filename must be given on the command line.  In all *
@@ -57,17 +57,18 @@ main(int argc, char* argv[])
 
         // Create major algorithm and data objects that comprise the
         // application.  These objects are configured from the input database.
-        Pointer<CartesianGridGeometry<NDIM> > grid_geometry = new CartesianGridGeometry<NDIM>(
+        Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
             "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
-        grid_geometry->addSpatialRefineOperator(new CartCellDoubleQuadraticRefine());    // refine op for cell-centered variables
-        grid_geometry->addSpatialRefineOperator(new CartSideDoubleRT0Refine());          // refine op for side-centered variables
-        Pointer<PatchHierarchy<NDIM> > patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
-        Pointer<StandardTagAndInitialize<NDIM> > error_detector = new StandardTagAndInitialize<NDIM>(
+        grid_geometry->addSpatialRefineOperator(new CartCellDoubleQuadraticRefine()); // refine op for cell-centered
+                                                                                      // variables
+        grid_geometry->addSpatialRefineOperator(new CartSideDoubleRT0Refine()); // refine op for side-centered variables
+        Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM>> error_detector = new StandardTagAndInitialize<NDIM>(
             "StandardTagAndInitialize", NULL, app_initializer->getComponentDatabase("StandardTagAndInitialize"));
-        Pointer<BergerRigoutsos<NDIM> > box_generator = new BergerRigoutsos<NDIM>();
-        Pointer<LoadBalancer<NDIM> > load_balancer =
+        Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM>> load_balancer =
             new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
-        Pointer<GriddingAlgorithm<NDIM> > gridding_algorithm =
+        Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
             new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
                                         app_initializer->getComponentDatabase("GriddingAlgorithm"),
                                         error_detector,
@@ -79,28 +80,29 @@ main(int argc, char* argv[])
         Pointer<VariableContext> ctx = var_db->getContext("context");
 
         // State variables: Velocity and pressure.
-        Pointer<SideVariable<NDIM, double> > un_sc_var = new SideVariable<NDIM, double>("un_sc");
-        Pointer<SideVariable<NDIM, double> > us_sc_var = new SideVariable<NDIM, double>("us_sc");
-        Pointer<CellVariable<NDIM, double> > p_cc_var = new CellVariable<NDIM, double>("p_cc");
+        Pointer<SideVariable<NDIM, double>> un_sc_var = new SideVariable<NDIM, double>("un_sc");
+        Pointer<SideVariable<NDIM, double>> us_sc_var = new SideVariable<NDIM, double>("us_sc");
+        Pointer<CellVariable<NDIM, double>> p_cc_var = new CellVariable<NDIM, double>("p_cc");
 
         // variable coefficient: theta_n
-        Pointer<CellVariable<NDIM, double> > thn_cc_var = new CellVariable<NDIM, double>("thn_cc");
+        Pointer<CellVariable<NDIM, double>> thn_cc_var = new CellVariable<NDIM, double>("thn_cc");
 
         // Results of operator "forces" and "divergence"
-        Pointer<SideVariable<NDIM, double> > f_un_sc_var = new SideVariable<NDIM, double>("f_un_sc");
-        Pointer<SideVariable<NDIM, double> > f_us_sc_var = new SideVariable<NDIM, double>("f_us_sc");
-        Pointer<CellVariable<NDIM, double> > f_cc_var = new CellVariable<NDIM, double>("f_cc");
+        Pointer<SideVariable<NDIM, double>> f_un_sc_var = new SideVariable<NDIM, double>("f_un_sc");
+        Pointer<SideVariable<NDIM, double>> f_us_sc_var = new SideVariable<NDIM, double>("f_us_sc");
+        Pointer<CellVariable<NDIM, double>> f_cc_var = new CellVariable<NDIM, double>("f_cc");
 
         // Error terms.
-        Pointer<SideVariable<NDIM, double> > e_un_sc_var = new SideVariable<NDIM, double>("e_un_sc");
-        Pointer<SideVariable<NDIM, double> > e_us_sc_var = new SideVariable<NDIM, double>("e_us_sc");
-        Pointer<CellVariable<NDIM, double> > e_cc_var = new CellVariable<NDIM, double>("e_cc");
+        Pointer<SideVariable<NDIM, double>> e_un_sc_var = new SideVariable<NDIM, double>("e_un_sc");
+        Pointer<SideVariable<NDIM, double>> e_us_sc_var = new SideVariable<NDIM, double>("e_us_sc");
+        Pointer<CellVariable<NDIM, double>> e_cc_var = new CellVariable<NDIM, double>("e_cc");
 
         // Register patch data indices...
         const int un_sc_idx = var_db->registerVariableAndContext(un_sc_var, ctx, IntVector<NDIM>(1));
         const int us_sc_idx = var_db->registerVariableAndContext(us_sc_var, ctx, IntVector<NDIM>(1));
         const int p_cc_idx = var_db->registerVariableAndContext(p_cc_var, ctx, IntVector<NDIM>(1));
-        const int thn_cc_idx = var_db->registerVariableAndContext(thn_cc_var, ctx, IntVector<NDIM>(1));  // 1 layer of ghost cells
+        const int thn_cc_idx =
+            var_db->registerVariableAndContext(thn_cc_var, ctx, IntVector<NDIM>(1)); // 1 layer of ghost cells
         const int f_cc_idx = var_db->registerVariableAndContext(f_cc_var, ctx, IntVector<NDIM>(1));
         const int f_un_sc_idx = var_db->registerVariableAndContext(f_un_sc_var, ctx, IntVector<NDIM>(1));
         const int f_us_sc_idx = var_db->registerVariableAndContext(f_us_sc_var, ctx, IntVector<NDIM>(1));
@@ -109,22 +111,22 @@ main(int argc, char* argv[])
         const int e_cc_idx = var_db->registerVariableAndContext(e_cc_var, ctx, IntVector<NDIM>(1));
 
         // Drawing variables
-        Pointer<CellVariable<NDIM, double> > draw_un_var = new CellVariable<NDIM, double>("draw_un", NDIM);
-        Pointer<CellVariable<NDIM, double> > draw_fn_var = new CellVariable<NDIM, double>("draw_fn", NDIM);
-        Pointer<CellVariable<NDIM, double> > draw_en_var = new CellVariable<NDIM, double>("draw_en", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_un_var = new CellVariable<NDIM, double>("draw_un", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_fn_var = new CellVariable<NDIM, double>("draw_fn", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_en_var = new CellVariable<NDIM, double>("draw_en", NDIM);
         const int draw_un_idx = var_db->registerVariableAndContext(draw_un_var, ctx);
         const int draw_fn_idx = var_db->registerVariableAndContext(draw_fn_var, ctx);
         const int draw_en_idx = var_db->registerVariableAndContext(draw_en_var, ctx);
 
-        Pointer<CellVariable<NDIM, double> > draw_us_var = new CellVariable<NDIM, double>("draw_us", NDIM);
-        Pointer<CellVariable<NDIM, double> > draw_fs_var = new CellVariable<NDIM, double>("draw_fs", NDIM);
-        Pointer<CellVariable<NDIM, double> > draw_es_var = new CellVariable<NDIM, double>("draw_es", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_us_var = new CellVariable<NDIM, double>("draw_us", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_fs_var = new CellVariable<NDIM, double>("draw_fs", NDIM);
+        Pointer<CellVariable<NDIM, double>> draw_es_var = new CellVariable<NDIM, double>("draw_es", NDIM);
         const int draw_us_idx = var_db->registerVariableAndContext(draw_us_var, ctx);
         const int draw_fs_idx = var_db->registerVariableAndContext(draw_fs_var, ctx);
         const int draw_es_idx = var_db->registerVariableAndContext(draw_es_var, ctx);
 
         // Register variables for plotting.
-        Pointer<VisItDataWriter<NDIM> > visit_data_writer = app_initializer->getVisItDataWriter();
+        Pointer<VisItDataWriter<NDIM>> visit_data_writer = app_initializer->getVisItDataWriter();
         TBOX_ASSERT(visit_data_writer);
 
         visit_data_writer->registerPlotQuantity("Pressure", "SCALAR", p_cc_idx);
@@ -182,7 +184,7 @@ main(int argc, char* argv[])
         // Allocate data on each level of the patch hierarchy.
         for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
         {
-            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
             level->allocatePatchData(un_sc_idx, 0.0);
             level->allocatePatchData(us_sc_idx, 0.0);
             level->allocatePatchData(f_un_sc_idx, 0.0);
@@ -272,17 +274,17 @@ main(int argc, char* argv[])
         Pointer<VCTwoFluidStaggeredStokesOperator> stokes_op = new VCTwoFluidStaggeredStokesOperator("stokes_op", true);
 
         stokes_op->setThnIdx(thn_cc_idx);
-    
-        Pointer<PETScKrylovLinearSolver> krylov_solver = new PETScKrylovLinearSolver(
-            "solver", app_initializer->getComponentDatabase("KrylovSolver"), "solver_");
+
+        Pointer<PETScKrylovLinearSolver> krylov_solver =
+            new PETScKrylovLinearSolver("solver", app_initializer->getComponentDatabase("KrylovSolver"), "solver_");
         krylov_solver->setOperator(stokes_op);
         krylov_solver->setNullspace(false, { null_vec });
         krylov_solver->initializeSolverState(u_vec, f_vec);
-        krylov_solver->solveSystem(u_vec,f_vec);
+        krylov_solver->solveSystem(u_vec, f_vec);
 
         // Compute error and print error norms.
-        e_vec.subtract(Pointer<SAMRAIVectorReal<NDIM, double> >(&u_vec, false),  // numerical
-                        Pointer<SAMRAIVectorReal<NDIM, double> >(&e_vec, false)); // analytical
+        e_vec.subtract(Pointer<SAMRAIVectorReal<NDIM, double>>(&u_vec, false),  // numerical
+                       Pointer<SAMRAIVectorReal<NDIM, double>>(&e_vec, false)); // analytical
         pout << "|e|_oo = " << e_vec.maxNorm() << "\n";
         pout << "|e|_2  = " << e_vec.L2Norm() << "\n";
         pout << "|e|_1  = " << e_vec.L1Norm() << "\n";
@@ -293,23 +295,25 @@ main(int argc, char* argv[])
         const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
         const int wgt_sc_idx = hier_math_ops.getSideWeightPatchDescriptorIndex();
 
-        HierarchySideDataOpsReal<NDIM, double> hier_sc_data_ops(patch_hierarchy, 0, patch_hierarchy->getFinestLevelNumber());
+        HierarchySideDataOpsReal<NDIM, double> hier_sc_data_ops(
+            patch_hierarchy, 0, patch_hierarchy->getFinestLevelNumber());
         pout << "Error in u_n :\n"
-                << "  L1-norm:  " << std::setprecision(10) << hier_sc_data_ops.L1Norm(e_un_sc_idx, wgt_sc_idx) << "\n"
-                << "  L2-norm:  " << hier_sc_data_ops.L2Norm(e_un_sc_idx, wgt_sc_idx) << "\n"
-                << "  max-norm: " << hier_sc_data_ops.maxNorm(e_un_sc_idx, wgt_sc_idx) << "\n";
+             << "  L1-norm:  " << std::setprecision(10) << hier_sc_data_ops.L1Norm(e_un_sc_idx, wgt_sc_idx) << "\n"
+             << "  L2-norm:  " << hier_sc_data_ops.L2Norm(e_un_sc_idx, wgt_sc_idx) << "\n"
+             << "  max-norm: " << hier_sc_data_ops.maxNorm(e_un_sc_idx, wgt_sc_idx) << "\n";
 
         pout << "Error in u_s :\n"
-                << "  L1-norm:  " << std::setprecision(10) << hier_sc_data_ops.L1Norm(e_us_sc_idx, wgt_sc_idx) << "\n"
-                << "  L2-norm:  " << hier_sc_data_ops.L2Norm(e_us_sc_idx, wgt_sc_idx) << "\n"
-                << "  max-norm: " << hier_sc_data_ops.maxNorm(e_us_sc_idx, wgt_sc_idx) << "\n";
+             << "  L1-norm:  " << std::setprecision(10) << hier_sc_data_ops.L1Norm(e_us_sc_idx, wgt_sc_idx) << "\n"
+             << "  L2-norm:  " << hier_sc_data_ops.L2Norm(e_us_sc_idx, wgt_sc_idx) << "\n"
+             << "  max-norm: " << hier_sc_data_ops.maxNorm(e_us_sc_idx, wgt_sc_idx) << "\n";
 
-        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy, 0, patch_hierarchy->getFinestLevelNumber());
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(
+            patch_hierarchy, 0, patch_hierarchy->getFinestLevelNumber());
         pout << "Error in p :\n"
-                << "  L1-norm:  " << hier_cc_data_ops.L1Norm(e_cc_idx, wgt_cc_idx) << "\n"
-                << "  L2-norm:  " << hier_cc_data_ops.L2Norm(e_cc_idx, wgt_cc_idx) << "\n"
-                << "  max-norm: " << hier_cc_data_ops.maxNorm(e_cc_idx, wgt_cc_idx) << "\n"
-                << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+             << "  L1-norm:  " << hier_cc_data_ops.L1Norm(e_cc_idx, wgt_cc_idx) << "\n"
+             << "  L2-norm:  " << hier_cc_data_ops.L2Norm(e_cc_idx, wgt_cc_idx) << "\n"
+             << "  max-norm: " << hier_cc_data_ops.maxNorm(e_cc_idx, wgt_cc_idx) << "\n"
+             << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
 
         // Interpolate the side-centered data to cell centers for output.
         static const bool synch_cf_interface = true;
@@ -326,7 +330,7 @@ main(int argc, char* argv[])
         // Allocate data on each level of the patch hierarchy.
         for (int ln = 0; ln <= patch_hierarchy->getFinestLevelNumber(); ++ln)
         {
-            Pointer<PatchLevel<NDIM> > level = patch_hierarchy->getPatchLevel(ln);
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
             level->deallocatePatchData(un_sc_idx);
             level->deallocatePatchData(us_sc_idx);
             level->deallocatePatchData(f_un_sc_idx);


### PR DESCRIPTION
This removes the compiler from `CMakeLists.txt` and also runs clang-format on the project. It now compiles correctly.

I've also renamed the `main2d` executable to `apply2d`