### PR TITLE
Ensure the dense hierarchy knows the coarsening and refinement operators.

### DIFF
--- a/tests/multigrid/FullFACPreconditioner.cpp
+++ b/tests/multigrid/FullFACPreconditioner.cpp
@@ -13,6 +13,8 @@
 
 /////////////////////////////// INCLUDES /////////////////////////////////////
 
+#include "ibtk/CartCellDoubleCubicCoarsen.h"
+#include "ibtk/CartSideDoubleCubicCoarsen.h"
 #include "ibtk/FACPreconditioner.h"
 #include "ibtk/FACPreconditionerStrategy.h"
 #include "ibtk/LinearSolver.h"
@@ -264,6 +266,10 @@ FullFACPreconditioner::generateDenseHierarchy(Pointer<PatchHierarchy<NDIM>> base
                                              base_level->getProcessorMapping());
         Pointer<PatchLevel<NDIM>> dense_level = d_dense_hierarchy->getPatchLevel(ln);
     }
+
+    Pointer<CartesianGridGeometry<NDIM>> cart_dense_geom = dense_geom;
+    cart_dense_geom->addSpatialCoarsenOperator(new CartCellDoubleCubicCoarsen());
+    cart_dense_geom->addSpatialCoarsenOperator(new CartSideDoubleCubicCoarsen());
 }
 
 void

--- a/tests/multigrid/FullFACPreconditioner.h
+++ b/tests/multigrid/FullFACPreconditioner.h
@@ -188,6 +188,11 @@ public:
 
     //\}
 
+    SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> getDenseHierarchy()
+    {
+        return d_dense_hierarchy;
+    }
+
 protected:
 private:
     int d_multigrid_max_levels = -1;


### PR DESCRIPTION
In order to lookup a refinement or coarsening operator, the grid geometry needs to be informed that they exist. This fixes that.

Also, we need to fill in the theta values in the dense hierarchy for the preconditioner.

This also correctly sets the nullspaces. There is one for the pressure and one for each component of the velocity.