### PR TITLE
Normal extensions

### DIFF
--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
@@ -73,35 +73,34 @@
 
 extern "C"
 {
-    void R_B_G_S(const double*, // dx
-                const int&,  // ilower0
-                const int&,  // iupper0
-                const int&,  // ilower1
-                const int&,  // iupper1
-                double* const, // un_data_0
-                double* const, // un_data_1
-                const int&,  // un_gcw
-                double* const, // us_data_0
-                double* const, // us_data_0
-                const int&, // us_gcw
-                double* const, // p_data_
-                const int&, // p_gcw
-                double* const, // f_p_data
-                const int&, // f_p_gcw
-                double* const, // f_un_data_0
-                double* const, // f_un_data_1
-                const int&,  // f_un_gcw
-                double* const, // f_us_data_0
-                double* const, // f_us_data_1
-                const int&, // f_us_gcw
-                double* const, // thn_data
-                const int&, // thn_gcw
-                const double&,  // eta_n    // whatever will be passed in will be treated as a reference to a double
-                const double&,  // eta_s    // telling the compiler that the function is expecting a reference
-                const double&,  // nu_n
-                const double&,  // nu_s 
-                const double&);  // xi
-                         
+    void R_B_G_S(const double*,  // dx
+                 const int&,     // ilower0
+                 const int&,     // iupper0
+                 const int&,     // ilower1
+                 const int&,     // iupper1
+                 double* const,  // un_data_0
+                 double* const,  // un_data_1
+                 const int&,     // un_gcw
+                 double* const,  // us_data_0
+                 double* const,  // us_data_0
+                 const int&,     // us_gcw
+                 double* const,  // p_data_
+                 const int&,     // p_gcw
+                 double* const,  // f_p_data
+                 const int&,     // f_p_gcw
+                 double* const,  // f_un_data_0
+                 double* const,  // f_un_data_1
+                 const int&,     // f_un_gcw
+                 double* const,  // f_us_data_0
+                 double* const,  // f_us_data_1
+                 const int&,     // f_us_gcw
+                 double* const,  // thn_data
+                 const int&,     // thn_gcw
+                 const double&,  // eta_n    // whatever will be passed in will be treated as a reference to a double
+                 const double&,  // eta_s    // telling the compiler that the function is expecting a reference
+                 const double&,  // nu_n
+                 const double&,  // nu_s
+                 const double&); // xi
 }
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 namespace IBTK
@@ -146,7 +145,7 @@ double convertToThs(double Thn);
 
 VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(
     const std::string& object_name,
-    //const Pointer<Database> input_db,
+    // const Pointer<Database> input_db,
     const std::string& default_options_prefix)
     : FACPreconditionerStrategy(object_name)
 {
@@ -385,8 +384,10 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(
             double* const f_p_ptr_data = f_p_data->getPointer(0);
 
             const Box<NDIM>& patch_box = patch->getBox();
-            const IntVector<NDIM>& patch_lower = patch_box.lower();  // patch_lower(0), patch_lower(1) are min indices in x and y-dir
-            const IntVector<NDIM>& patch_upper = patch_box.upper();  // patch_upper(0), patch_upper(1) are max indices in x and y-dir
+            const IntVector<NDIM>& patch_lower =
+                patch_box.lower(); // patch_lower(0), patch_lower(1) are min indices in x and y-dir
+            const IntVector<NDIM>& patch_upper =
+                patch_box.upper(); // patch_upper(0), patch_upper(1) are max indices in x and y-dir
 
             const IntVector<NDIM>& thn_gcw = thn_data->getGhostCellWidth();
             const IntVector<NDIM>& un_gcw = un_data->getGhostCellWidth();
@@ -395,32 +396,36 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(
             const IntVector<NDIM>& f_un_gcw = f_un_data->getGhostCellWidth();
             const IntVector<NDIM>& f_us_gcw = f_us_data->getGhostCellWidth();
             const IntVector<NDIM>& f_p_gcw = f_p_data->getGhostCellWidth();
-            R_B_G_S(dx,  
-                    patch_lower(0),  // ilower0
-                    patch_upper(0),  // iupper0
-                    patch_lower(1),  // ilower1
-                    patch_upper(1),  // iupper1
-                    un_data_0, 
-                    un_data_1, 
-                    un_gcw.min(),  
-                    us_data_0, 
-                    us_data_1, 
-                    us_gcw.min(), 
-                    p_ptr_data, 
-                    p_gcw.min(), 
-                    f_p_ptr_data, 
+            R_B_G_S(dx,
+                    patch_lower(0), // ilower0
+                    patch_upper(0), // iupper0
+                    patch_lower(1), // ilower1
+                    patch_upper(1), // iupper1
+                    un_data_0,
+                    un_data_1,
+                    un_gcw.min(),
+                    us_data_0,
+                    us_data_1,
+                    us_gcw.min(),
+                    p_ptr_data,
+                    p_gcw.min(),
+                    f_p_ptr_data,
                     f_p_gcw.min(),
-                    f_un_data_0, 
-                    f_un_data_1, 
-                    f_un_gcw.min(),  
-                    f_us_data_0, 
+                    f_un_data_0,
+                    f_un_data_1,
+                    f_un_gcw.min(),
+                    f_us_data_0,
                     f_us_data_1,
-                    f_us_gcw.min(), 
-                    thn_ptr_data, 
+                    f_us_gcw.min(),
+                    thn_ptr_data,
                     thn_gcw.min(),
-                    eta_n, eta_s, nu_n, nu_s, xi);
+                    eta_n,
+                    eta_s,
+                    nu_n,
+                    nu_s,
+                    xi);
         } // patchess
-    } // num_sweeps
+    }     // num_sweeps
     IBTK_TIMER_STOP(t_smooth_error);
     return;
 }
@@ -458,7 +463,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
     const int res_us_idx = residual.getComponentDescriptorIndex(1);
     const int res_P_idx = residual.getComponentDescriptorIndex(2);
     const int thn_idx = d_thn_idx;
-    
+
     d_un_fill_pattern = new SideNoCornersFillPattern(SIDEG, false, false, true);
     d_us_fill_pattern = new SideNoCornersFillPattern(SIDEG, false, false, true);
     d_P_fill_pattern = new CellNoCornersFillPattern(CELLG, false, false, true);
@@ -716,7 +721,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::setToZero(SAMRAIVectorReal<ND
     Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(level_num);
     for (PatchLevel<NDIM>::Iterator p(level); p; p++)
     {
-        Pointer<Patch<NDIM>> patch = level->getPatch(p()); 
+        Pointer<Patch<NDIM>> patch = level->getPatch(p());
         Pointer<SideData<NDIM, double>> un_data = patch->getPatchData(un_idx);
         Pointer<SideData<NDIM, double>> us_data = patch->getPatchData(us_idx);
         Pointer<CellData<NDIM, double>> p_data = patch->getPatchData(P_idx);

--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h
@@ -282,4 +282,4 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
-#endif //#ifndef included_IBTK_VCTwoFluidStaggeredStokesBoxRelaxationFACOperator
+#endif // #ifndef included_IBTK_VCTwoFluidStaggeredStokesBoxRelaxationFACOperator

--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h
@@ -266,6 +266,11 @@ private:
      */
     std::vector<std::vector<SAMRAI::hier::BoxList<NDIM>>> d_patch_bc_box_overlap;
 
+    /*
+     * Coarse-fine interface interpolation objects.
+     */
+    SAMRAI::tbox::Pointer<CoarseFineBoundaryRefinePatchStrategy> d_sc_bdry_op, d_cc_bdry_op;
+
     // Cache the prolongation and restriction schedules
     SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineOperator<NDIM>> d_un_prolong_op, d_us_prolong_op, d_p_prolong_op;
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenOperator<NDIM>> d_un_restrict_op, d_us_restrict_op, d_p_restrict_op;

--- a/VCTwoFluidStaggeredStokesOperator.cpp
+++ b/VCTwoFluidStaggeredStokesOperator.cpp
@@ -252,7 +252,7 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                                                              DATA_COARSEN_TYPE,
                                                              BDRY_EXTRAP_TYPE,
                                                              CONSISTENT_TYPE_2_BDRY,
-                                                             d_un_bc_coefs, 
+                                                             d_un_bc_coefs,
                                                              d_un_fill_pattern);
     transaction_comps[1] = InterpolationTransactionComponent(us_idx,
                                                              us_idx,
@@ -261,7 +261,7 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                                                              DATA_COARSEN_TYPE,
                                                              BDRY_EXTRAP_TYPE,
                                                              CONSISTENT_TYPE_2_BDRY,
-                                                             d_us_bc_coefs, 
+                                                             d_us_bc_coefs,
                                                              d_us_fill_pattern);
     transaction_comps[2] = InterpolationTransactionComponent(P_idx,
                                                              CC_DATA_REFINE_TYPE,
@@ -393,18 +393,21 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 (*A_un_data)(idx) = ddx_Thn_dx_un + ddy_Thn_dy_un + ddy_Thn_dx_vn + ddx_Thn_dy_vn + drag_n + pressure_n;
 
                 // solvent equation
-                double ddx_Ths_dx_us = eta_s / (dx[0] * dx[0]) *
-                                        (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(idx + xp) - (*us_data)(idx)) -
-                                        convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(idx) - (*us_data)(idx - xp)));
+                double ddx_Ths_dx_us =
+                    eta_s / (dx[0] * dx[0]) *
+                    (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(idx + xp) - (*us_data)(idx)) -
+                     convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(idx) - (*us_data)(idx - xp)));
                 double ddy_Ths_dy_us = eta_s / (dx[1] * dx[1]) *
                                        (convertToThs(thn_imhalf_jphalf) * ((*us_data)(idx + yp) - (*us_data)(idx)) -
                                         convertToThs(thn_imhalf_jmhalf) * ((*us_data)(idx) - (*us_data)(idx - yp)));
-                double ddy_Ths_dx_vs = eta_s / (dx[1] * dx[0]) *
-                                       (convertToThs(thn_imhalf_jphalf) * ((*us_data)(upper_y_idx) - (*us_data)(u_y_idx)) -
-                                       convertToThs(thn_imhalf_jmhalf) * ((*us_data)(lower_y_idx) - (*us_data)(l_y_idx)));
-                double ddx_Ths_dy_vs = -eta_s / (dx[0] * dx[1]) *
-                                        (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(upper_y_idx) - (*us_data)(lower_y_idx)) -
-                                        convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(u_y_idx) - (*us_data)(l_y_idx)));
+                double ddy_Ths_dx_vs =
+                    eta_s / (dx[1] * dx[0]) *
+                    (convertToThs(thn_imhalf_jphalf) * ((*us_data)(upper_y_idx) - (*us_data)(u_y_idx)) -
+                     convertToThs(thn_imhalf_jmhalf) * ((*us_data)(lower_y_idx) - (*us_data)(l_y_idx)));
+                double ddx_Ths_dy_vs =
+                    -eta_s / (dx[0] * dx[1]) *
+                    (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(upper_y_idx) - (*us_data)(lower_y_idx)) -
+                     convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(u_y_idx) - (*us_data)(l_y_idx)));
 
                 double drag_s = -xi / nu_s * thn_lower * convertToThs(thn_lower) * ((*us_data)(idx) - (*un_data)(idx));
                 double pressure_s = -convertToThs(thn_lower) / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
@@ -454,18 +457,21 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 (*A_un_data)(idx) = ddy_Thn_dy_un + ddx_Thn_dx_un + ddx_Thn_dy_vn + ddy_Thn_dx_vn + drag_n + pressure_n;
 
                 // Solvent equation
-                double ddy_Ths_dy_us = eta_s / (dx[1] * dx[1]) *
-                                        (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(idx + yp) - (*us_data)(idx)) -
-                                        convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(idx) - (*us_data)(idx - yp)));
+                double ddy_Ths_dy_us =
+                    eta_s / (dx[1] * dx[1]) *
+                    (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(idx + yp) - (*us_data)(idx)) -
+                     convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(idx) - (*us_data)(idx - yp)));
                 double ddx_Ths_dx_us = eta_s / (dx[0] * dx[0]) *
-                                        (convertToThs(thn_iphalf_jmhalf) * ((*us_data)(idx + xp) - (*us_data)(idx)) -
+                                       (convertToThs(thn_iphalf_jmhalf) * ((*us_data)(idx + xp) - (*us_data)(idx)) -
                                         convertToThs(thn_imhalf_jmhalf) * ((*us_data)(idx) - (*us_data)(idx - xp)));
-                double ddx_Ths_dy_vs = eta_s / (dx[1] * dx[0]) *
-                                        (convertToThs(thn_iphalf_jmhalf) * ((*us_data)(upper_x_idx) - (*us_data)(u_x_idx)) -
-                                        convertToThs(thn_imhalf_jmhalf) * ((*us_data)(lower_x_idx) - (*us_data)(l_x_idx)));
-                double ddy_Ths_dx_vs = -eta_s / (dx[0] * dx[1]) *
-                                        (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(upper_x_idx) - (*us_data)(lower_x_idx)) -
-                                        convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(u_x_idx) - (*us_data)(l_x_idx)));
+                double ddx_Ths_dy_vs =
+                    eta_s / (dx[1] * dx[0]) *
+                    (convertToThs(thn_iphalf_jmhalf) * ((*us_data)(upper_x_idx) - (*us_data)(u_x_idx)) -
+                     convertToThs(thn_imhalf_jmhalf) * ((*us_data)(lower_x_idx) - (*us_data)(l_x_idx)));
+                double ddy_Ths_dx_vs =
+                    -eta_s / (dx[0] * dx[1]) *
+                    (convertToThs((*thn_data)(idx_c_up)) * ((*us_data)(upper_x_idx) - (*us_data)(lower_x_idx)) -
+                     convertToThs((*thn_data)(idx_c_low)) * ((*us_data)(u_x_idx) - (*us_data)(l_x_idx)));
 
                 double drag_s = -xi / nu_s * thn_lower * convertToThs(thn_lower) * ((*us_data)(idx) - (*un_data)(idx));
                 double pressure_s = -convertToThs(thn_lower) / dx[1] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));

--- a/VCTwoFluidStaggeredStokesOperator.h
+++ b/VCTwoFluidStaggeredStokesOperator.h
@@ -275,4 +275,4 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
-#endif //#ifndef included_IBAMR_TwoFluidStaggeredStokesOperator
+#endif // #ifndef included_IBAMR_TwoFluidStaggeredStokesOperator

--- a/multigrid.cpp
+++ b/multigrid.cpp
@@ -34,8 +34,8 @@
 #include <StandardTagAndInitialize.h>
 
 // Local includes
-#include "VCTwoFluidStaggeredStokesOperator.h"
 #include "VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h"
+#include "VCTwoFluidStaggeredStokesOperator.h"
 #include "tests/multigrid/FullFACPreconditioner.h"
 
 /*******************************************************************************

--- a/smooth.cpp
+++ b/smooth.cpp
@@ -270,31 +270,31 @@ main(int argc, char* argv[])
         un_fcn.setDataOnPatchHierarchy(un_sc_idx, un_sc_var, patch_hierarchy, 0.0);
         us_fcn.setDataOnPatchHierarchy(us_sc_idx, us_sc_var, patch_hierarchy, 0.0);
         p_fcn.setDataOnPatchHierarchy(p_cc_idx, p_cc_var, patch_hierarchy, 0.0);
-        
+
         // Setup the box relaxation FAC operator
 
         VCTwoFluidStaggeredStokesBoxRelaxationFACOperator box_relax("box_relax", "");
         box_relax.setThnIdx(thn_cc_idx);
-        //box_relax.initializeOperatorState(u_vec,f_vec);
+        // box_relax.initializeOperatorState(u_vec,f_vec);
         box_relax.setToZero(u_vec, 0);
 
-        for (int i = 0; i <= 680; i++){
-            box_relax.smoothError(u_vec, f_vec, 0, 1, false, false); 
+        for (int i = 0; i <= 680; i++)
+        {
+            box_relax.smoothError(u_vec, f_vec, 0, 1, false, false);
             box_relax.computeResidual(e_vec, u_vec, f_vec, 0, 0);
             pout << "Sweep = " << i << "\n";
             pout << "|r|_2  = " << e_vec.L2Norm() << "\n";
         }
-        
-        
+
         // Setup the stokes operator
         // VCTwoFluidStaggeredStokesOperator stokes_op("stokes_op", true);
         // stokes_op.setThnIdx(thn_cc_idx);
         // stokes_op.initializeOperatorState(u_vec, e_vec);
         // stokes_op.apply(u_vec, e_vec); // e_vec is A*u
-       
+
         // calculate residual norm: b - A*u
         // f_vec.subtract(Pointer<SAMRAIVectorReal<NDIM, double>>(&f_vec, false),  // RHS
-                       //Pointer<SAMRAIVectorReal<NDIM, double>>(&e_vec, false)); // A*u
+        // Pointer<SAMRAIVectorReal<NDIM, double>>(&e_vec, false)); // A*u
         // pout << "|r|_oo = " << e_vec.maxNorm() << "\n";
         // pout << "|r|_2  = " << e_vec.L2Norm() << "\n";
         // pout << "|r|_1  = " << e_vec.L1Norm() << "\n";

--- a/tests/multigrid/CCPointFACPreconditionerStrategy.h
+++ b/tests/multigrid/CCPointFACPreconditionerStrategy.h
@@ -533,4 +533,4 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
-#endif //#ifndef included_IBTK_CCPointFACPreconditionerStrategy
+#endif // #ifndef included_IBTK_CCPointFACPreconditionerStrategy

--- a/tests/multigrid/CCPointRelaxationFACOperator.h
+++ b/tests/multigrid/CCPointRelaxationFACOperator.h
@@ -256,4 +256,4 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
-#endif //#ifndef included_IBTK_CCPointRelaxationFACOperator
+#endif // #ifndef included_IBTK_CCPointRelaxationFACOperator

--- a/tests/multigrid/FullFACPreconditioner.cpp
+++ b/tests/multigrid/FullFACPreconditioner.cpp
@@ -46,7 +46,8 @@ FullFACPreconditioner::FullFACPreconditioner(std::string object_name,
                                              Pointer<Database> input_db,
                                              int multigrid_max_levels,
                                              const std::string& default_options_prefix)
-    : FACPreconditioner(std::move(object_name), fac_strategy, input_db, default_options_prefix), d_multigrid_max_levels(multigrid_max_levels)
+    : FACPreconditioner(std::move(object_name), fac_strategy, input_db, default_options_prefix),
+      d_multigrid_max_levels(multigrid_max_levels)
 {
     return;
 } // FACPreconditioner
@@ -112,7 +113,7 @@ FullFACPreconditioner::solveSystem(SAMRAIVectorReal<NDIM, double>& u, SAMRAIVect
 
     transferToBase(u, *d_u);
 
-    // Inform preconditioner of the nullspace. 
+    // Inform preconditioner of the nullspace.
     const std::vector<Pointer<SAMRAIVectorReal<NDIM, double>>>& null_vecs = getNullspaceBasisVectors();
     for (const auto& null_vec : null_vecs)
     {

--- a/tests/multigrid/FullFACPreconditioner.h
+++ b/tests/multigrid/FullFACPreconditioner.h
@@ -243,4 +243,4 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 
-#endif //#ifndef included_IBTK_FACPreconditioner
+#endif // #ifndef included_IBTK_FACPreconditioner


### PR DESCRIPTION
This computes the normal extension to fill in ghost cells at coarse fine interfaces using quadratic extrapolation. There's also a commit that runs clang-format on the entire project.