### PR TITLE
Set parameters via functions

### DIFF
--- a/VCTwoFluidStaggeredStokesOperator.cpp
+++ b/VCTwoFluidStaggeredStokesOperator.cpp
@@ -498,7 +498,9 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double drag_n =
                     -d_xi / d_nu_n * thn_lower * convertToThs(thn_lower) * ((*un_data)(idx) - (*us_data)(idx));
                 double pressure_n = -thn_lower / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*A_un_data)(idx) = d_D*(ddx_Thn_dx_un + ddy_Thn_dy_un + ddy_Thn_dx_vn + ddx_Thn_dy_vn + drag_n + pressure_n) + d_C*(*un_data)(idx);
+                (*A_un_data)(idx) =
+                    d_D * (ddx_Thn_dx_un + ddy_Thn_dy_un + ddy_Thn_dx_vn + ddx_Thn_dy_vn + drag_n + pressure_n) +
+                    d_C * thn_lower * (*un_data)(idx);
 
                 // solvent equation
                 double ddx_Ths_dx_us =
@@ -519,7 +521,9 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double drag_s =
                     -d_xi / d_nu_s * thn_lower * convertToThs(thn_lower) * ((*us_data)(idx) - (*un_data)(idx));
                 double pressure_s = -convertToThs(thn_lower) / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*A_us_data)(idx) = d_D*(ddx_Ths_dx_us + ddy_Ths_dy_us + ddy_Ths_dx_vs + ddx_Ths_dy_vs + drag_s + pressure_s) + d_C*(*us_data)(idx);
+                (*A_us_data)(idx) =
+                    d_D * (ddx_Ths_dx_us + ddy_Ths_dy_us + ddy_Ths_dx_vs + ddx_Ths_dy_vs + drag_s + pressure_s) +
+                    d_C * convertToThs(thn_lower) * (*us_data)(idx);
             }
 
             for (SideIterator<NDIM> si(patch->getBox(), 1); si; si++) // side-centers in y-dir
@@ -561,7 +565,9 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double drag_n =
                     -d_xi / d_nu_n * thn_lower * convertToThs(thn_lower) * ((*un_data)(idx) - (*us_data)(idx));
                 double pressure_n = -thn_lower / dx[1] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*A_un_data)(idx) = d_D*(ddy_Thn_dy_un + ddx_Thn_dx_un + ddx_Thn_dy_vn + ddy_Thn_dx_vn + drag_n + pressure_n) + d_C*(*un_data)(idx);
+                (*A_un_data)(idx) =
+                    d_D * (ddy_Thn_dy_un + ddx_Thn_dx_un + ddx_Thn_dy_vn + ddy_Thn_dx_vn + drag_n + pressure_n) +
+                    d_C * thn_lower * (*un_data)(idx);
 
                 // Solvent equation
                 double ddy_Ths_dy_us =
@@ -582,7 +588,9 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double drag_s =
                     -d_xi / d_nu_s * thn_lower * convertToThs(thn_lower) * ((*us_data)(idx) - (*un_data)(idx));
                 double pressure_s = -convertToThs(thn_lower) / dx[1] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*A_us_data)(idx) = d_D*(ddy_Ths_dy_us + ddx_Ths_dx_us + ddx_Ths_dy_vs + ddy_Ths_dx_vs + drag_s + pressure_s) + d_C*(*us_data)(idx);
+                (*A_us_data)(idx) =
+                    d_D * (ddy_Ths_dy_us + ddx_Ths_dx_us + ddx_Ths_dy_vs + ddy_Ths_dx_vs + drag_s + pressure_s) +
+                    d_C * convertToThs(thn_lower) * (*us_data)(idx);
             }
         }
     }

--- a/VCTwoFluidStaggeredStokesOperator.h
+++ b/VCTwoFluidStaggeredStokesOperator.h
@@ -59,9 +59,9 @@ namespace IBAMR
  * incompressible flow solver.
  *
  * This class knows how to apply the following operator:
- * [ C*thn + A_n + D*xi/nu_n*thn*ths            D*xi/nu_n*thn*ths        thn*grad ][un]
- * [         D*xi/nu_s*thn*ths         C*ths + A_s + D*xi/nu_s*thn*ths   ths*grad ][us]
- * [         div(thn)                           div(ths)                    0     ][p ]
+ * [ C*thn + A_n + D*xi/nu_n*thn*ths   -D*xi/nu_n*thn*ths                 thn*grad ][un]
+ * [ -D*xi/nu_s*thn*ths                 C*ths + A_s + D*xi/nu_s*thn*ths   ths*grad ][us]
+ * [ div(thn)                          div(ths)                          0         ][p ]
  * in which
  * A_i = D*eta_i*div(thn*((grad+grad^T)-div*I))
  *

--- a/VCTwoFluidStaggeredStokesOperator.h
+++ b/VCTwoFluidStaggeredStokesOperator.h
@@ -58,6 +58,26 @@ namespace IBAMR
  * This class is intended to be used with an iterative (Krylov or Newton-Krylov)
  * incompressible flow solver.
  *
+ * This class knows how to apply the following operator:
+ * [ C*thn + A_n + D*xi/nu_n*thn*ths            D*xi/nu_n*thn*ths        thn*grad ][un]
+ * [         D*xi/nu_s*thn*ths         C*ths + A_s + D*xi/nu_s*thn*ths   ths*grad ][us]
+ * [         div(thn)                           div(ths)                    0     ][p ]
+ * in which
+ * A_i = D*eta_i*div(thn*((grad+grad^T)-div*I))
+ *
+ * The following parameters must be supplied before the operator can be applied:
+ *   -- C: Constant, set via setVelocityPoissonSpecifications().
+ *   -- D: Constant, set via setVelocityPoissonSpecifications().
+ *   -- thn: Cell centered patch index for volume fraction, set via setThnIdx().
+ *   -- xi: Constant drag coefficient, set via setDragCoefficient().
+ *   -- eta_n: Constant viscosity, set via setViscosityCoefficient().
+ *   -- eta_s: Constant viscosity, set via setViscosityCoefficient().
+ *   -- nu_n: Constant, set via setDragCoefficient().
+ *   -- nu_s: Constant, set via setDragCoefficient().
+ *
+ * Note that unlike StaggeredStokesOperator, xi, eta, and mu MUST be provided separately from C and D. C and D values
+ * are typically set by the time stepping scheme.
+ *
  * \see INSStaggeredHierarchyIntegrator
  */
 class VCTwoFluidStaggeredStokesOperator : public IBTK::LinearOperator
@@ -65,38 +85,48 @@ class VCTwoFluidStaggeredStokesOperator : public IBTK::LinearOperator
 public:
     /*!
      * \brief Class constructor.
+     *
+     * The optional database will search for the following strings:
+     *  -- "c" - double
+     *  -- "d" - double
+     *  -- "xi" - double
+     *  -- "eta_n" - double
+     *  -- "eta_s" - double
+     *  -- "nu_n" - double
+     *  -- "nu_s" - double
      */
-    VCTwoFluidStaggeredStokesOperator(const std::string& object_name, bool homogeneous_bc, const double C, const double D);
+    VCTwoFluidStaggeredStokesOperator(const std::string& object_name,
+                                      bool homogeneous_bc,
+                                      SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db = nullptr);
 
     /*!
      * \brief Destructor.
-     * \param C scaler-valued C in C*u term used to add diagonal dominance
-     * \param D scaler-valued D for time-dependent stokes 
      */
     ~VCTwoFluidStaggeredStokesOperator();
 
     /*!
-     * \brief Set the PoissonSpecifications object used to specify the
-     * coefficients for the momentum equation in the incompressible Stokes
-     * operator.
+     * \brief Set the PoissonSpecifications object used to specify the C and D values for the momentum equations
+     *
+     * \note Must be constant values at this time.
      */
-    virtual void
-    setVelocityPoissonSpecifications(const SAMRAI::solv::PoissonSpecifications& un_problem_coefs,
-                                     const SAMRAI::solv::PoissonSpecifications& us_problem_coefs); // might be modified
+    void setVelocityPoissonSpecifications(const SAMRAI::solv::PoissonSpecifications& coefs); // might be modified
+
+    void setCandDCoefficients(double C, double D);
 
     /*!
-     * \brief Get the PoissonSpecifications object used to specify the
-     * coefficients for the network momentum equation in the incompressible Stokes
-     * operator.
+     * \brief Set the viscosity coefficients for the viscous stresses.
      */
-    virtual const SAMRAI::solv::PoissonSpecifications& getNetworkVelocityPoissonSpecifications() const;
+    void setViscosityCoefficient(double eta_n, double eta_s);
 
     /*!
-     * \brief Get the PoissonSpecifications object used to specify the
-     * coefficients for the solvent momentum equation in the incompressible Stokes
-     * operator.
+     * \brief Set the drag coefficients for each phase.
      */
-    virtual const SAMRAI::solv::PoissonSpecifications& getSolventVelocityPoissonSpecifications() const;
+    void setDragCoefficient(double xi, double nu_n, double nu_s);
+
+    /*!
+     * \brief Set the cell centered patch index for the volume fraction.
+     */
+    void setThnIdx(int thn_idx);
 
     /*!
      * \brief Set the SAMRAI::solv::RobinBcCoefStrategy objects used to specify
@@ -157,10 +187,6 @@ public:
      * \param x input
      * \param y output: y=Ax
      */
-
-    void setThnIdx(int thn_idx);
-    // brief This method sets up the patch data indices for Thn variable
-
     void apply(SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& x,
                SAMRAI::solv::SAMRAIVectorReal<NDIM, double>& y) override;
 
@@ -223,16 +249,12 @@ public:
 
 protected:
     // Problem specification.
-    SAMRAI::solv::PoissonSpecifications d_un_problem_coefs; // might create a different set for second fluid equation
-    SAMRAI::solv::PoissonSpecifications d_us_problem_coefs; // might create a different set for second fluid equation
     SAMRAI::solv::RobinBcCoefStrategy<NDIM>* d_default_un_bc_coef;
     SAMRAI::solv::RobinBcCoefStrategy<NDIM>* d_default_us_bc_coef;
     std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_un_bc_coefs;
     std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_us_bc_coefs;
     SAMRAI::solv::RobinBcCoefStrategy<NDIM>* d_default_P_bc_coef;
     SAMRAI::solv::RobinBcCoefStrategy<NDIM>* d_P_bc_coef;
-    double d_C = std::numeric_limits<double>::quiet_NaN(); // C*u
-    double d_D = std::numeric_limits<double>::quiet_NaN();  
 
     // Reference patch hierarchy
     SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> d_hierarchy;
@@ -248,7 +270,6 @@ protected:
 
     // Scratch data.
     SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_x, d_b;
-    int d_thn_idx;
 
 private:
     /*!
@@ -284,6 +305,13 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenOperator<NDIM>> d_os_coarsen_op;
     SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenAlgorithm<NDIM>> d_os_coarsen_alg;
     std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenSchedule<NDIM>>> d_os_coarsen_scheds;
+
+    /// Parameters
+    double d_C = std::numeric_limits<double>::quiet_NaN(), d_D = std::numeric_limits<double>::quiet_NaN();
+    int d_thn_idx = IBTK::invalid_index;
+    double d_xi = std::numeric_limits<double>::quiet_NaN(), d_nu_n = std::numeric_limits<double>::quiet_NaN(),
+           d_nu_s = std::numeric_limits<double>::quiet_NaN();
+    double d_eta_n = std::numeric_limits<double>::quiet_NaN(), d_eta_s = std::numeric_limits<double>::quiet_NaN();
 };
 } // namespace IBAMR
 

--- a/apply.cpp
+++ b/apply.cpp
@@ -266,7 +266,11 @@ main(int argc, char* argv[])
 
         // Setup the stokes operator
         const double C = input_db->getDouble("C");
-        VCTwoFluidStaggeredStokesOperator stokes_op("stokes_op", true, C);
+        const double D = input_db->getDouble("D");
+        VCTwoFluidStaggeredStokesOperator stokes_op("stokes_op", true);
+        stokes_op.setCandDCoefficients(C, D);
+        stokes_op.setDragCoefficient(1.0, 1.0, 1.0);
+        stokes_op.setViscosityCoefficient(1.0, 1.0);
 
         stokes_op.setThnIdx(thn_cc_idx);
         stokes_op.initializeOperatorState(u_vec, f_vec);

--- a/input2d.var_theta.var_vel
+++ b/input2d.var_theta.var_vel
@@ -1,5 +1,9 @@
 USE_PRECOND = TRUE
 w = 0.75
+w = 0.75
+C = 0.0
+D = 1.0
+IS_VEL_NULLSPACE = FALSE
 
 un {
    function_0 = "cos(2*PI*X_0)*cos(2*PI*X_1)"

--- a/multigrid.cpp
+++ b/multigrid.cpp
@@ -304,9 +304,12 @@ main(int argc, char* argv[])
         p_fcn.setDataOnPatchHierarchy(e_cc_idx, e_cc_var, patch_hierarchy, 0.0);
 
         // Setup the stokes operator
-        Pointer<VCTwoFluidStaggeredStokesOperator> stokes_op =
-            new VCTwoFluidStaggeredStokesOperator("stokes_op", true, input_db->getDouble("C"));
-
+        Pointer<VCTwoFluidStaggeredStokesOperator> stokes_op = new VCTwoFluidStaggeredStokesOperator("stokes_op", true);
+        const double C = input_db->getDouble("C");
+        const double D = input_db->getDouble("D");
+        stokes_op->setCandDCoefficients(C, D);
+        stokes_op->setDragCoefficient(1.0, 1.0, 1.0);
+        stokes_op->setViscosityCoefficient(1.0, 1.0);
         stokes_op->setThnIdx(thn_cc_idx);
 
         Pointer<PETScKrylovLinearSolver> krylov_solver =

--- a/solver.cpp
+++ b/solver.cpp
@@ -272,6 +272,11 @@ main(int argc, char* argv[])
 
         // Setup the stokes operator
         Pointer<VCTwoFluidStaggeredStokesOperator> stokes_op = new VCTwoFluidStaggeredStokesOperator("stokes_op", true);
+        const double C = input_db->getDouble("C");
+        const double D = input_db->getDouble("D");
+        stokes_op->setCandDCoefficients(C, D);
+        stokes_op->setDragCoefficient(1.0, 1.0, 1.0);
+        stokes_op->setViscosityCoefficient(1.0, 1.0);
 
         stokes_op->setThnIdx(thn_cc_idx);
 


### PR DESCRIPTION
This creates functions to set constants (C, D, eta, nu, xi, etc). Also allows a database to be provided in the constructor to read them.

Note that the correct C and D values MUST be provided for the system to make sense (i.e., if you want to invert the system, C and D should probably have alternate signs). The values of C and D are set via the chosen time stepping scheme. For example, for backward Euler, C = 1.0/dt, D = -1.0. For trapezoidal rule, C = 1.0/dt, D = -0.5.