### PR TITLE
Various fixes to the timestepping and multigrid operators.

### DIFF
--- a/FullFACPreconditioner.cpp
+++ b/FullFACPreconditioner.cpp
@@ -44,11 +44,10 @@ namespace IBTK
 FullFACPreconditioner::FullFACPreconditioner(std::string object_name,
                                              Pointer<FACPreconditionerStrategy> fac_strategy,
                                              Pointer<Database> input_db,
-                                             int multigrid_max_levels,
                                              const std::string& default_options_prefix)
-    : FACPreconditioner(std::move(object_name), fac_strategy, input_db, default_options_prefix),
-      d_multigrid_max_levels(multigrid_max_levels)
+    : FACPreconditioner(std::move(object_name), fac_strategy, input_db, default_options_prefix)
 {
+    d_multigrid_max_levels = input_db->getInteger("max_multigrid_levels");
     return;
 } // FACPreconditioner
 

--- a/FullFACPreconditioner.h
+++ b/FullFACPreconditioner.h
@@ -75,7 +75,6 @@ public:
     FullFACPreconditioner(std::string object_name,
                           SAMRAI::tbox::Pointer<FACPreconditionerStrategy> fac_strategy,
                           SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> input_db,
-                          int multigrid_max_levels,
                           const std::string& default_options_prefix);
 
     /*!

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.h
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.h
@@ -257,7 +257,7 @@ private:
      */
     SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> d_precond_db;
     double d_w = std::numeric_limits<double>::quiet_NaN();
-    int d_max_multigrid_levels = -1;
+    bool d_use_preconditioner = true;
 
     /*!
      * Velocity Drawing information.

--- a/RBGS.f
+++ b/RBGS.f
@@ -254,7 +254,8 @@ c
           A_box(9, 9) = 0.0
 c
           ! network at west edge
-          b(1) = f_un_data_0(i0,i1)-thn_lower_x/dx(0)*p_data(i0-1,i1) - 
+          b(1) = f_un_data_0(i0,i1)+D*(-thn_lower_x/dx(0)*
+     &        p_data(i0-1,i1) -
      &        eta_n / (dx(0)* dx(0)) * 
      &        thn_data(i0-1,i1) * un_data_0(i0-1,i1) -
      &        eta_n / (dx(1)* dx(1)) * 
@@ -266,10 +267,10 @@ c
      &        eta_n / (dx(0)* dx(1)) * 
      &        thn_imhalf_jmhalf * un_data_1(i0-1,i1) -
      &        eta_n / (dx(0)* dx(1)) * thn_data(i0-1,i1) *
-     &        (un_data_1(i0-1,i1+1) - un_data_1(i0-1,i1))
+     &        (un_data_1(i0-1,i1+1) - un_data_1(i0-1,i1)))
 c
           ! solvent at west edge
-          b(5) = f_us_data_0(i0,i1)-toThs(thn_lower_x) / dx(0) * 
+          b(5) = f_us_data_0(i0,i1)+D*(-toThs(thn_lower_x) / dx(0) *
      &      p_data(i0-1,i1) -
      &      eta_s / (dx(0)* dx(0)) * 
      &      toThs(thn_data(i0-1,i1)) * us_data_0(i0-1,i1) -
@@ -283,10 +284,10 @@ c
      &      toThs(thn_imhalf_jmhalf) * us_data_1(i0-1,i1) -
      &      eta_s / (dx(0)* dx(1)) * 
      &      toThs(thn_data(i0-1,i1)) *
-     &      (us_data_1(i0-1,i1+1) - us_data_1(i0-1,i1))
+     &      (us_data_1(i0-1,i1+1) - us_data_1(i0-1,i1)))
 c
           ! network at east edge
-          b(2) = f_un_data_0(i0+1,i1) + thn_upper_x / dx(0) * 
+          b(2) = f_un_data_0(i0+1,i1) + D*(thn_upper_x / dx(0) *
      &        p_data(i0+1,i1) -
      &        eta_n / (dx(0)* dx(0)) * thn_data(i0+1,i1) * 
      &        un_data_0(i0+2,i1) -
@@ -299,10 +300,10 @@ c
      &        eta_n / (dx(0)* dx(1)) * thn_iphalf_jmhalf * 
      &        un_data_1(i0+1,i1) +
      &        eta_n / (dx(0)* dx(1)) * thn_data(i0+1,i1) *
-     &        (un_data_1(i0+1,i1+1) - un_data_1(i0+1,i1))
+     &        (un_data_1(i0+1,i1+1) - un_data_1(i0+1,i1)))
 c
           ! solvent at east edge
-          b(6) = f_us_data_0(i0+1,i1) + toThs(thn_upper_x) / dx(0) * 
+          b(6) = f_us_data_0(i0+1,i1) + D*(toThs(thn_upper_x) / dx(0) *
      &    p_data(i0+1,i1) -
      &    eta_s / (dx(0)* dx(0)) * toThs(thn_data(i0+1,i1)) * 
      &    us_data_0(i0+2,i1) -
@@ -315,10 +316,10 @@ c
      &    eta_s / (dx(0)* dx(1)) * toThs(thn_iphalf_jmhalf) * 
      &    us_data_1(i0+1,i1) +
      &    eta_s / (dx(0)* dx(1)) * toThs(thn_data(i0+1,i1)) *
-     &        (us_data_1(i0+1,i1+1) - us_data_1(i0+1,i1))
+     &        (us_data_1(i0+1,i1+1) - us_data_1(i0+1,i1)))
 c
           ! network at south edge
-          b(3) = f_un_data_1(i0,i1)-thn_lower_y / dx(1) * 
+          b(3) = f_un_data_1(i0,i1)+D*(-thn_lower_y / dx(1) *
      &        p_data(i0,i1-1) -
      &        eta_n / (dx(1)* dx(1)) * thn_data(i0,i1-1) * 
      &        un_data_1(i0,i1-1) -
@@ -331,10 +332,10 @@ c
      &        eta_n / (dx(0)* dx(1)) * thn_imhalf_jmhalf * 
      &        un_data_0(i0,i1-1) -
      &        eta_n / (dx(0)* dx(1)) * thn_data(i0,i1-1) *
-     &        (un_data_0(i0+1,i1-1) - un_data_0(i0,i1-1))
+     &        (un_data_0(i0+1,i1-1) - un_data_0(i0,i1-1)))
 c
           ! solvent at south edge
-          b(7) = f_us_data_1(i0,i1)-toThs(thn_lower_y) / dx(1) * 
+          b(7) = f_us_data_1(i0,i1)+D*(-toThs(thn_lower_y) / dx(1) *
      &    p_data(i0,i1-1) -
      &    eta_s / (dx(1)* dx(1)) * toThs(thn_data(i0,i1-1)) * 
      &    us_data_1(i0,i1-1) -
@@ -347,10 +348,10 @@ c
      &    eta_s / (dx(0)* dx(1)) * toThs(thn_imhalf_jmhalf) * 
      &    us_data_0(i0,i1-1) -
      &    eta_s / (dx(0)* dx(1)) * toThs(thn_data(i0,i1-1)) *
-     &    (us_data_0(i0+1,i1-1) - us_data_0(i0,i1-1))
+     &    (us_data_0(i0+1,i1-1) - us_data_0(i0,i1-1)))
 c
           ! network at north edge
-          b(4) = f_un_data_1(i0,i1+1) + thn_upper_y / dx(1) * 
+          b(4) = f_un_data_1(i0,i1+1) + D*(thn_upper_y / dx(1) *
      &        p_data(i0,i1+1) -
      &        eta_n / (dx(1)* dx(1)) * thn_data(i0,i1+1) * 
      &        un_data_1(i0,i1+2) -
@@ -363,10 +364,10 @@ c
      &        eta_n / (dx(0)* dx(1)) * thn_imhalf_jphalf * 
      &        un_data_0(i0,i1 + 1) +
      &        eta_n / (dx(0)* dx(1)) * thn_data(i0,i1+1) *
-     &        (un_data_0(i0+1,i1+1) - un_data_0(i0,i1 + 1))
+     &        (un_data_0(i0+1,i1+1) - un_data_0(i0,i1 + 1)))
 c
           ! solvent at north edge
-          b(8) =  f_us_data_1(i0,i1+1) + toThs(thn_upper_y) / dx(1)*
+          b(8) =  f_us_data_1(i0,i1+1) + D*(toThs(thn_upper_y) / dx(1)*
      &    p_data(i0,i1+1) -
      &    eta_s / (dx(1)* dx(1)) * toThs(thn_data(i0,i1+1)) * 
      &    us_data_1(i0,i1+2) -
@@ -379,13 +380,13 @@ c
      &    eta_s / (dx(0)* dx(1)) * toThs(thn_imhalf_jphalf) * 
      &    us_data_0(i0,i1 + 1) +
      &    eta_s / (dx(0)* dx(1)) * toThs(thn_data(i0,i1+1)) *
-     &    (us_data_0(i0+1,i1+1) - us_data_0(i0,i1 + 1))
+     &    (us_data_0(i0+1,i1+1) - us_data_0(i0,i1 + 1)))
 c
           ! pressure at cell center
           b(9) = f_p_data(i0,i1)
 c
           ! CALL dgetrf( 9, 9, A_box, 9, ipiv, info)
-          
+
           !IF( info.EQ.0 ) THEN
           !     print *, 'info is:'
                ! Solve the system A*X = B, overwriting B with X.
@@ -395,7 +396,7 @@ c    &               9, info )
 
           ! solve the system Ax = b, overwriting b with x
           call dgesv(9, 1, A_box, 9, ipiv, b, 9, info)
-c         
+c
           if (info /= 0) then
             ! print *, A_box
             print *, 'ERROR IN DGESV'
@@ -414,7 +415,7 @@ c
 c
         enddo
       enddo
-c     
+c
       end subroutine
 
 

--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
@@ -444,6 +444,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(
 
         } // patchess
     }     // num_sweeps
+    performGhostFilling({ un_idx, us_idx, P_idx }, level_num);
     IBTK_TIMER_STOP(t_smooth_error);
     return;
 }

--- a/input2d.const_theta.var_vel.timestepping
+++ b/input2d.const_theta.var_vel.timestepping
@@ -1,0 +1,134 @@
+RHO = 1.0
+MAX_MULTIGRID_LEVELS = 5
+START_TIME = 0.0
+END_TIME = 1.0
+NUM_CYCLES = 1
+DT_MAX = 0.005
+ENABLE_LOGGING = TRUE
+W = 0.75
+USE_PRECONDITIONER = TRUE
+
+VIZ_DUMP_TIME_INTERVAL = 0.01
+
+un {
+   function_0 = "0.0"
+   function_1 = "0.0"
+}
+
+us {
+   function_0 = "0.0"
+   function_1 = "0.0"
+} // so that average of un + us is 0
+
+p {
+   function = "0.0"
+} // pressure has mean 0
+
+f_un {
+   function_0 = "-0.5 * (1 + 8*PI*PI)*cos(2*PI*X_0)*cos(2*PI*X_1)"
+   function_1 = "-0.5*(1+8*PI*PI)*cos(2*PI*X_0)*cos(2*PI*X_1)"
+}
+
+f_us {
+   function_0 = "0.5*(1+8*PI*PI)*cos(2*PI*X_0)*cos(2*PI*X_1)"
+   function_1 = "0.5*(1+8*PI*PI)*cos(2*PI*X_0)*cos(2*PI*X_1)"
+}
+
+f_p {
+   function = "0.0"
+}
+
+thn {
+   function = "0.5"
+}
+
+INSVCTwoFluidStaggeredHierarchyIntegrator {
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   num_cycles                    = NUM_CYCLES
+   dt_max                        = DT_MAX
+   enable_logging                = ENABLE_LOGGING
+   w = W
+   use_preconditioner = USE_PRECONDITIONER
+
+   solver_db {
+      ksp_type = "fgmres"
+   }
+
+   precond_db {
+      cycle_type = "V_CYCLE"
+      num_pre_sweeps = 3
+      num_post_sweeps = 3
+      enable_logging = TRUE
+      max_multigrid_levels = MAX_MULTIGRID_LEVELS
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d_multigrid"
+   visit_number_procs_per_file = 1
+
+// timer dump parameters
+   timer_enabled = TRUE
+}
+
+N = 64
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0      // lower end of computational domain.
+   x_up               = 1, 1      // upper end of computational domain.
+   periodic_dimension = 1, 1  
+}
+
+GriddingAlgorithm {
+   max_levels = 2                 // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 2, 2              // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 512, 512          // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4          // smallest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+    // level_0 = [( N/4 , N/4 ),( 3*N/4 - 1 , N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1, 3*N/4 - 2)]
+    // level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )] // L-shaped refinement
+     level_0 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+    // level_0 = [(N/4 + 5 , N/4 + 5),( N/4 + 10, N/4 + 10)] 
+    // level_0 = [(1,1), (30,30)] 
+   }
+}
+
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 1.0
+   timer_list = "IBTK::*::*"
+}

--- a/input2d.timestepping
+++ b/input2d.timestepping
@@ -1,3 +1,9 @@
+USE_PRECOND = TRUE
+w = 0.75
+C = 0.0
+D = 1.0
+IS_VEL_NULLSPACE = FALSE
+
 un {
    function_0 = "0.0"
    function_1 = "0.0"
@@ -35,7 +41,7 @@ MAX_MULTIGRID_LEVELS = 5
 START_TIME = 0.0
 END_TIME = 1.0
 NUM_CYCLES = 1
-DT_MAX = 0.005
+DT_MAX = 0.0005
 ENABLE_LOGGING = TRUE
 W = 0.75
 
@@ -48,14 +54,14 @@ Main {
 
 // visualization dump parameters
    viz_writer = "VisIt"
-   viz_dump_dirname = "viz2d_timestepping"
+   viz_dump_dirname = "viz2d_multigrid1"
    visit_number_procs_per_file = 1
 
 // timer dump parameters
    timer_enabled = TRUE
 }
 
-N = 32
+N = 64
 
 CartesianGeometry {
    domain_boxes       = [(0,0), (N - 1,N - 1)]
@@ -79,10 +85,9 @@ INSVCTwoFluidStaggeredHierarchyIntegrator {
    dt_max                        = DT_MAX
    enable_logging                = ENABLE_LOGGING
    w = W
-   max_multigrid_levels = MAX_MULTIGRID_LEVELS
 
    solver_db {
-
+      ksp_type = "fgmres"
    }
 
    precond_db {
@@ -90,6 +95,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator {
       num_pre_sweeps = 5
       num_post_sweeps = 5
       enable_logging = TRUE
+      max_multigrid_levels = MAX_MULTIGRID_LEVELS
    }
 }
 
@@ -97,7 +103,7 @@ MultigridAlg {
 }
 
 GriddingAlgorithm {
-   max_levels = 2                 // Maximum number of levels in hierarchy.
+   max_levels = 1                 // Maximum number of levels in hierarchy.
 
    ratio_to_coarser {
       level_1 = 4, 4              // vector ratio to next coarser level

--- a/multigrid.cpp
+++ b/multigrid.cpp
@@ -330,7 +330,6 @@ main(int argc, char* argv[])
             new FullFACPreconditioner("KrylovPrecond",
                                       fac_precondition_strategy,
                                       app_initializer->getComponentDatabase("KrylovPrecond"),
-                                      input_db->getInteger("multigrid_max_levels"),
                                       "Krylov_precond_");
         bool use_precond = input_db->getBool("USE_PRECOND");
         Krylov_precond->setNullspace(false, null_vecs);


### PR DESCRIPTION
The time stepping routine now runs (presumably) correctly.

  -- Correctly add the factor D to the multigrid smoother to account for
timestepping.
  -- Remove the member variables max_multigrid_level and make them an
input database option to the solver.
  -- Add an option to ignore the preconditioner.
  -- Fix ghost cells when filling in the RHS.