### PR TITLE
Print out errors for timestepping example

### DIFF
--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -190,6 +190,30 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::getPressureSubdomainSolver()
     return nullptr;
 } // getPressureSubdomainSolver
 
+Pointer<SideVariable<NDIM, double>>
+INSVCTwoFluidStaggeredHierarchyIntegrator::getSolventVariable() const
+{
+    return d_us_sc_var;
+}
+
+Pointer<SideVariable<NDIM, double>>
+INSVCTwoFluidStaggeredHierarchyIntegrator::getNetworkVariable() const
+{
+    return d_un_sc_var;
+}
+
+Pointer<CellVariable<NDIM, double>>
+INSVCTwoFluidStaggeredHierarchyIntegrator::getPressureVariable() const
+{
+    return d_p_cc_var;
+}
+
+Pointer<VariableContext>
+INSVCTwoFluidStaggeredHierarchyIntegrator::getContext() const
+{
+    return d_ctx;
+}
+
 void
 INSVCTwoFluidStaggeredHierarchyIntegrator::setInitialData(Pointer<CartGridFunction> un_fcn,
                                                           Pointer<CartGridFunction> us_fcn,
@@ -456,6 +480,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::integrateHierarchy(const double curre
                 double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up)); // thn(i-1/2,j)
                 (*f_un_data)(idx) = (*f_un_data)(idx) + C * thn_lower * (*un_data)(idx);
                 (*f_us_data)(idx) = (*f_us_data)(idx) + C * convertToThs(thn_lower) * (*us_data)(idx);
+                if (idx(0) == 0 && idx(1) == 0) pout << "(*us_data)(" << idx << ") = " << (*us_data)(idx) << "\n";
             }
 
             for (SideIterator<NDIM> si(patch->getBox(), 1); si; si++) // side-centers in y-dir

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -480,7 +480,6 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::integrateHierarchy(const double curre
                 double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up)); // thn(i-1/2,j)
                 (*f_un_data)(idx) = (*f_un_data)(idx) + C * thn_lower * (*un_data)(idx);
                 (*f_us_data)(idx) = (*f_us_data)(idx) + C * convertToThs(thn_lower) * (*us_data)(idx);
-                if (idx(0) == 0 && idx(1) == 0) pout << "(*us_data)(" << idx << ") = " << (*us_data)(idx) << "\n";
             }
 
             for (SideIterator<NDIM> si(patch->getBox(), 1); si; si++) // side-centers in y-dir

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.h
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.h
@@ -117,6 +117,26 @@ public:
     SAMRAI::tbox::Pointer<IBTK::PoissonSolver> getPressureSubdomainSolver() override;
 
     /*!
+     * Get solvent velocity variable.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> getSolventVariable() const;
+
+    /*!
+     * Get network velocity variable.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> getNetworkVariable() const;
+
+    /*!
+     * Get pressure velocity variable.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> getPressureVariable() const;
+
+    /*!
+     * Get the context used in the hierarchy.
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> getContext() const;
+
+    /*!
      * Set initial conditions for the state variables
      */
     void setInitialData(SAMRAI::tbox::Pointer<IBTK::CartGridFunction> un_fcn,

--- a/input2d.const_theta.var_vel.timestepping
+++ b/input2d.const_theta.var_vel.timestepping
@@ -7,7 +7,7 @@ DT_MAX = 0.005
 ENABLE_LOGGING = TRUE
 W = 0.75
 USE_PRECONDITIONER = TRUE
-
+N = 128
 VIZ_DUMP_TIME_INTERVAL = 0.01
 
 un {
@@ -18,7 +18,7 @@ un {
 us {
    function_0 = "0.0"
    function_1 = "0.0"
-} // so that average of un + us is 0
+}
 
 p {
    function = "0.0"
@@ -42,6 +42,20 @@ thn {
    function = "0.5"
 }
 
+un_exact {
+   function_0 = "-cos(2*PI*X_0)*cos(2*PI*X_1)"
+   function_1 = "-cos(2*PI*X_1)*cos(2*PI*X_0)"
+}
+
+us_exact {
+   function_0 = "cos(2*PI*X_0)*cos(2*PI*X_1)"
+   function_1 = "cos(2*PI*X_1)*cos(2*PI*X_0)"
+} // so that average of un + us is 0
+
+p_exact {
+   function = "0.0"
+} // pressure has mean 0
+
 INSVCTwoFluidStaggeredHierarchyIntegrator {
    rho                           = RHO
    start_time                    = START_TIME
@@ -58,8 +72,8 @@ INSVCTwoFluidStaggeredHierarchyIntegrator {
 
    precond_db {
       cycle_type = "V_CYCLE"
-      num_pre_sweeps = 3
-      num_post_sweeps = 3
+      num_pre_sweeps = 5
+      num_post_sweeps = 5
       enable_logging = TRUE
       max_multigrid_levels = MAX_MULTIGRID_LEVELS
    }
@@ -72,14 +86,12 @@ Main {
 
 // visualization dump parameters
    viz_writer = "VisIt"
-   viz_dump_dirname = "viz2d_multigrid"
+   viz_dump_dirname = "viz2d_timestepping"
    visit_number_procs_per_file = 1
 
 // timer dump parameters
    timer_enabled = TRUE
 }
-
-N = 64
 
 CartesianGeometry {
    domain_boxes       = [(0,0), (N - 1,N - 1)]
@@ -89,7 +101,7 @@ CartesianGeometry {
 }
 
 GriddingAlgorithm {
-   max_levels = 2                 // Maximum number of levels in hierarchy.
+   max_levels = 1                 // Maximum number of levels in hierarchy.
 
    ratio_to_coarser {
       level_1 = 2, 2              // vector ratio to next coarser level

--- a/time_stepping.cpp
+++ b/time_stepping.cpp
@@ -123,6 +123,14 @@ main(int argc, char* argv[])
         // Visualization files info.
         double viz_dump_time_interval = input_db->getDouble("VIZ_DUMP_TIME_INTERVAL");
         double next_viz_dump_time = 0.0;
+        // At specified intervals, write visualization files
+        if (IBTK::abs_equal_eps(loop_time, next_viz_dump_time, 0.1 * dt) || loop_time >= next_viz_dump_time)
+        {
+            pout << "\nWriting visualization files...\n\n";
+            ins_integrator->setupPlotData();
+            visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+            next_viz_dump_time += viz_dump_time_interval;
+        }
         // Main time step loop
         while (!IBTK::rel_equal_eps(loop_time, time_end) && ins_integrator->stepsRemaining())
         {
@@ -153,5 +161,80 @@ main(int argc, char* argv[])
                 next_viz_dump_time += viz_dump_time_interval;
             }
         }
+
+        // Compute errors.
+        Pointer<CartGridFunction> un_exact_fcn =
+            new muParserCartGridFunction("UN_exact", app_initializer->getComponentDatabase("un_exact"), grid_geometry);
+        Pointer<CartGridFunction> us_exact_fcn =
+            new muParserCartGridFunction("US_exact", app_initializer->getComponentDatabase("us_exact"), grid_geometry);
+        Pointer<CartGridFunction> p_exact_fcn =
+            new muParserCartGridFunction("P_exact", app_initializer->getComponentDatabase("p_exact"), grid_geometry);
+
+        // Get the current data.
+        Pointer<SideVariable<NDIM, double>> un_var = ins_integrator->getNetworkVariable();
+        Pointer<SideVariable<NDIM, double>> us_var = ins_integrator->getSolventVariable();
+        Pointer<CellVariable<NDIM, double>> p_var = ins_integrator->getPressureVariable();
+
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<VariableContext> ctx = ins_integrator->getContext();
+        const int un_idx = var_db->mapVariableAndContextToIndex(un_var, ctx);
+        const int us_idx = var_db->mapVariableAndContextToIndex(us_var, ctx);
+        const int p_idx = var_db->mapVariableAndContextToIndex(p_var, ctx);
+
+        // Create scratch data.
+        Pointer<VariableContext> exa_ctx = var_db->getContext("Exact");
+        const int un_exa_idx = var_db->registerVariableAndContext(un_var, exa_ctx);
+        const int us_exa_idx = var_db->registerVariableAndContext(us_var, exa_ctx);
+        const int p_exa_idx = var_db->registerVariableAndContext(p_var, exa_ctx);
+
+        // Allocate scratch data
+        const int coarsest_ln = 0;
+        const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(un_exa_idx, loop_time);
+            level->allocatePatchData(us_exa_idx, loop_time);
+            level->allocatePatchData(p_exa_idx, loop_time);
+        }
+
+        // Fill in exact values
+        un_exact_fcn->setDataOnPatchHierarchy(
+            un_exa_idx, un_var, patch_hierarchy, loop_time, false, coarsest_ln, finest_ln);
+        us_exact_fcn->setDataOnPatchHierarchy(
+            us_exa_idx, us_var, patch_hierarchy, loop_time, false, coarsest_ln, finest_ln);
+        p_exact_fcn->setDataOnPatchHierarchy(
+            p_exa_idx, p_var, patch_hierarchy, loop_time, false, coarsest_ln, finest_ln);
+
+        HierarchyMathOps hier_math_ops("hier_math_ops", patch_hierarchy, coarsest_ln, finest_ln);
+        const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
+        const int wgt_sc_idx = hier_math_ops.getSideWeightPatchDescriptorIndex();
+        HierarchySideDataOpsReal<NDIM, double> hier_sc_data_ops(patch_hierarchy, coarsest_ln, finest_ln);
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy, coarsest_ln, finest_ln);
+
+        // Compute error and print out norms.
+        hier_sc_data_ops.subtract(un_idx, un_idx, un_exa_idx);
+        hier_sc_data_ops.subtract(us_idx, us_idx, us_exa_idx);
+        hier_cc_data_ops.subtract(p_idx, p_idx, p_exa_idx);
+        pout << "Printing error norms\n\n";
+        pout << "Newtork velocity\n";
+        pout << "Un L1-norm:  " << hier_sc_data_ops.L1Norm(un_idx, wgt_sc_idx) << "\n";
+        pout << "Un L1-norm:  " << hier_sc_data_ops.L2Norm(un_idx, wgt_sc_idx) << "\n";
+        pout << "Un max-norm: " << hier_sc_data_ops.maxNorm(un_idx, wgt_sc_idx) << "\n\n";
+
+        pout << "Solvent velocity\n";
+        pout << "Us L1-norm:  " << hier_sc_data_ops.L1Norm(us_idx, wgt_sc_idx) << "\n";
+        pout << "Us L1-norm:  " << hier_sc_data_ops.L2Norm(us_idx, wgt_sc_idx) << "\n";
+        pout << "Us max-norm: " << hier_sc_data_ops.maxNorm(us_idx, wgt_sc_idx) << "\n\n";
+
+        pout << "Pressure\n";
+        pout << "P L1-norm:  " << hier_cc_data_ops.L1Norm(p_idx, wgt_cc_idx) << "\n";
+        pout << "P L1-norm:  " << hier_cc_data_ops.L2Norm(p_idx, wgt_cc_idx) << "\n";
+        pout << "P max-norm: " << hier_cc_data_ops.maxNorm(p_idx, wgt_cc_idx) << "\n";
+
+        // Print extra viz files for the error
+        pout << "\nWriting visualization files...\n\n";
+        ins_integrator->setupPlotData();
+        visit_data_writer->writePlotData(patch_hierarchy, iteration_num + 1, loop_time);
     } // cleanup dynamically allocated objects prior to shutdown
 } // main


### PR DESCRIPTION
Currently shows second order accuracy for manufactured solution.