### PR TITLE
Make things work with advanceHierarchy()

### DIFF
--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -387,7 +387,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(
         }
 
         // deallocate the gradient patch data on dense hierarchy here?
-        
+
     return;
 } // applyGradientDetectorSpecialized
 
@@ -431,6 +431,8 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     const int un_scr_idx = var_db->mapVariableAndContextToIndex(d_un_sc_var, getScratchContext());
     const int us_scr_idx = var_db->mapVariableAndContextToIndex(d_us_sc_var, getScratchContext());
     const int p_scr_idx = var_db->mapVariableAndContextToIndex(d_P_var, getScratchContext());
+    const int grad_x_thn_idx = var_db->mapVariableAndContextToIndex(d_grad_x_thn_var, getCurrentContext());
+    const int grad_y_thn_idx = var_db->mapVariableAndContextToIndex(d_grad_y_thn_var, getCurrentContext());
 
     // Allocate scratch and new data
     for (int ln = coarsest_ln; ln <= finest_ln; ++ln)

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -460,22 +460,6 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     if (d_f_us_fcn) d_f_us_fcn->setDataOnPatchHierarchy(f_us_idx, d_f_us_sc_var, d_hierarchy, current_time);
     if (d_f_p_fcn) d_f_p_fcn->setDataOnPatchHierarchy(f_p_idx, d_f_cc_var, d_hierarchy, current_time);
 
-    // Need to fill in ghost cells for theta to do interpolation
-    {
-        using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
-        std::vector<ITC> ghost_cell_comp(1);
-        ghost_cell_comp[0] = ITC(thn_idx,
-                                 "CONSERVATIVE_LINEAR_REFINE",
-                                 false,
-                                 "NONE",
-                                 "LINEAR",
-                                 true,
-                                 nullptr); // defaults to fill corner
-        HierarchyGhostCellInterpolation ghost_cell_fill;
-        ghost_cell_fill.initializeOperatorState(ghost_cell_comp, d_hierarchy, 0, d_hierarchy->getFinestLevelNumber());
-        ghost_cell_fill.fillData(0.0);
-    }
-
     // set-up RHS to treat viscosity and drag with backward Euler or Implicit Trapezoidal Rule:
     // RHS = f(n) + C*theta_i(n)*u_i(n) + D1*(pressure + viscous + drag) for  i = n, s
     double D1 = std::numeric_limits<double>::signaling_NaN();

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -607,7 +607,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::integrateHierarchy(const double curre
 
     // Set the initial guess for the system to be the most recent approximation to t^{n+1}
     d_hier_sc_data_ops->copyData(d_sol_vec->getComponentDescriptorIndex(0), un_new_idx);
-    d_hier_sc_data_ops->copyData(d_sol_vec->getComponentDescriptorIndex(1), un_new_idx);
+    d_hier_sc_data_ops->copyData(d_sol_vec->getComponentDescriptorIndex(1), us_new_idx);
     d_hier_cc_data_ops->copyData(d_sol_vec->getComponentDescriptorIndex(2), p_new_idx);
 
     // Solve for un(n+1), us(n+1), p(n+1).

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.h
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.h
@@ -242,6 +242,8 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_un_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_us_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_thn_cc_var;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_grad_x_thn_var;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_grad_y_thn_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_f_un_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_f_us_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_f_cc_var;

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.h
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.h
@@ -242,11 +242,17 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_un_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_us_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_thn_cc_var;
-    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_grad_x_thn_var;
-    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_grad_y_thn_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_f_un_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_f_us_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_f_cc_var;
+
+    /*!
+     * Gradient detector variables
+     */
+    bool d_use_grad_tagging = false;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_grad_thn_var;
+    SAMRAI::tbox::Array<double> d_abs_grad_thresh, d_rel_grad_thresh;
+    double d_max_grad_thn = std::numeric_limits<double>::quiet_NaN();
 
     /*!
      * Vectors

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.h
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.h
@@ -43,33 +43,10 @@
 #include <string>
 #include <vector>
 
-namespace IBAMR
-{
-class ConvectiveOperator;
-} // namespace IBAMR
-namespace IBTK
-{
-class PoissonSolver;
-} // namespace IBTK
-namespace SAMRAI
-{
-namespace hier
-{
-template <int DIM>
-class BasePatchLevel;
-template <int DIM>
-class Patch;
-template <int DIM>
-class PatchHierarchy;
-template <int DIM>
-class BasePatchHierarchy;
-} // namespace hier
-namespace mesh
-{
-template <int DIM>
-class GriddingAlgorithm;
-} // namespace mesh
-} // namespace SAMRAI
+// Local includes
+#include "FullFACPreconditioner.h"
+#include "VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h"
+#include "VCTwoFluidStaggeredStokesOperator.h"
 
 /////////////////////////////// CLASS DEFINITION /////////////////////////////
 
@@ -130,11 +107,6 @@ public:
      * Get pressure velocity variable.
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> getPressureVariable() const;
-
-    /*!
-     * Get the context used in the hierarchy.
-     */
-    SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> getContext() const;
 
     /*!
      * Set initial conditions for the state variables
@@ -211,6 +183,22 @@ public:
 
     void synchronizeHierarchyDataSpecialized(IBTK::VariableContextType ctx_type) override;
 
+    /*!
+     * Reset cached hierarchy dependent data.
+     */
+    void resetHierarchyConfigurationSpecialized(SAMRAI::tbox::Pointer<SAMRAI::hier::BasePatchHierarchy<NDIM>> hierarchy,
+                                                int coarsest_level,
+                                                int finest_level) override;
+
+    void applyGradientDetectorSpecialized(const SAMRAI::tbox::Pointer<SAMRAI::hier::BasePatchHierarchy<NDIM>> hierarchy,
+                                          int level_num,
+                                          double error_data_time,
+                                          int tag_idx,
+                                          bool initial_time,
+                                          bool uses_richardson_extrapolation_too);
+
+    int getNumberOfCycles() const override;
+
 protected:
     void setupPlotDataSpecialized() override;
 
@@ -253,16 +241,17 @@ private:
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_un_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_us_sc_var;
-    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_p_cc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_thn_cc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_f_un_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_f_us_sc_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_f_cc_var;
 
-    /*
-     * Variable context
+    /*!
+     * Vectors
      */
-    SAMRAI::tbox::Pointer<SAMRAI::hier::VariableContext> d_ctx;
+    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_sol_vec;
+    SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_rhs_vec;
+    std::vector<SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>>> d_nul_vecs;
 
     // Density
     double d_rho = std::numeric_limits<double>::quiet_NaN();
@@ -271,11 +260,15 @@ private:
      * Solver information
      */
     SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> d_solver_db;
+    SAMRAI::tbox::Pointer<IBTK::PETScKrylovLinearSolver> d_stokes_solver;
+    SAMRAI::tbox::Pointer<VCTwoFluidStaggeredStokesOperator> d_stokes_op;
 
     /*!
      * Preconditioner information
      */
     SAMRAI::tbox::Pointer<SAMRAI::tbox::Database> d_precond_db;
+    SAMRAI::tbox::Pointer<IBTK::FullFACPreconditioner> d_stokes_precond;
+    SAMRAI::tbox::Pointer<VCTwoFluidStaggeredStokesBoxRelaxationFACOperator> d_precond_op;
     double d_w = std::numeric_limits<double>::quiet_NaN();
     bool d_use_preconditioner = true;
 
@@ -283,6 +276,12 @@ private:
      * Velocity Drawing information.
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::NodeVariable<NDIM, double>> d_un_draw_var, d_us_draw_var;
+
+    /*!
+     * Objects that can do the operations we need
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::math::HierarchyCellDataOpsReal<NDIM, double>> d_hier_cc_data_ops;
+    SAMRAI::tbox::Pointer<SAMRAI::math::HierarchySideDataOpsReal<NDIM, double>> d_hier_sc_data_ops;
 };
 } // namespace IBAMR
 

--- a/input2d.const_theta.var_vel.timestepping
+++ b/input2d.const_theta.var_vel.timestepping
@@ -9,7 +9,6 @@ W = 0.75
 USE_PRECONDITIONER = TRUE
 N = 128
 VIZ_DUMP_TIME_INTERVAL = 0.01
-VISCOUS_TIME_STEPPING_TYPE = "TRAPEZOIDAL_RULE"
 
 un {
    function_0 = "0.0"
@@ -66,7 +65,6 @@ INSVCTwoFluidStaggeredHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    w = W
    use_preconditioner = USE_PRECONDITIONER
-   viscous_time_stepping_type = VISCOUS_TIME_STEPPING_TYPE
 
    solver_db {
       ksp_type = "fgmres"
@@ -74,8 +72,8 @@ INSVCTwoFluidStaggeredHierarchyIntegrator {
 
    precond_db {
       cycle_type = "V_CYCLE"
-      num_pre_sweeps = 5
-      num_post_sweeps = 5
+      num_pre_sweeps = 2
+      num_post_sweeps = 2
       enable_logging = TRUE
       max_multigrid_levels = MAX_MULTIGRID_LEVELS
    }

--- a/time_stepping.cpp
+++ b/time_stepping.cpp
@@ -217,17 +217,17 @@ main(int argc, char* argv[])
         pout << "Printing error norms\n\n";
         pout << "Newtork velocity\n";
         pout << "Un L1-norm:  " << hier_sc_data_ops.L1Norm(un_idx, wgt_sc_idx) << "\n";
-        pout << "Un L1-norm:  " << hier_sc_data_ops.L2Norm(un_idx, wgt_sc_idx) << "\n";
+        pout << "Un L2-norm:  " << hier_sc_data_ops.L2Norm(un_idx, wgt_sc_idx) << "\n";
         pout << "Un max-norm: " << hier_sc_data_ops.maxNorm(un_idx, wgt_sc_idx) << "\n\n";
 
         pout << "Solvent velocity\n";
         pout << "Us L1-norm:  " << hier_sc_data_ops.L1Norm(us_idx, wgt_sc_idx) << "\n";
-        pout << "Us L1-norm:  " << hier_sc_data_ops.L2Norm(us_idx, wgt_sc_idx) << "\n";
+        pout << "Us L2-norm:  " << hier_sc_data_ops.L2Norm(us_idx, wgt_sc_idx) << "\n";
         pout << "Us max-norm: " << hier_sc_data_ops.maxNorm(us_idx, wgt_sc_idx) << "\n\n";
 
         pout << "Pressure\n";
         pout << "P L1-norm:  " << hier_cc_data_ops.L1Norm(p_idx, wgt_cc_idx) << "\n";
-        pout << "P L1-norm:  " << hier_cc_data_ops.L2Norm(p_idx, wgt_cc_idx) << "\n";
+        pout << "P L2-norm:  " << hier_cc_data_ops.L2Norm(p_idx, wgt_cc_idx) << "\n";
         pout << "P max-norm: " << hier_cc_data_ops.maxNorm(p_idx, wgt_cc_idx) << "\n";
 
         // Print extra viz files for the error


### PR DESCRIPTION
There are a few significant changes here.

1. State variables (pressure, velocity) are now created with the `registerVariable` interface, which sets them up to be reinitialized on regridding.
2. You can retrieve patch indices for state variables with the `VariableDatabase<NDIM>` and with `getCurrentContext()`, `getNewContext()`, and `getScratchContext()`. The current context holds the current values.
3. There are side and cell centered math objects `d_hier_[s|c]c_data_manager` to do any kind of copying/vector operations on patch indices.
4. Solvers and vectors are created in `preprocessHierarchyIntegrator`. All `integrateHierarchy` does now is solve the system.

The function that decides _when to regrid_ is not implemented in this class.  It is `atRegridPointSpecialized` for which a default implementation is provided in the base class `HierarchyIntegrator`. The default implementation regrids after a set number of time steps provided by the input database option `regrid_interval`.