### PR TITLE
Adv diff integrator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,8 @@ ADD_EXECUTABLE(time_stepping time_stepping.cpp)
 TARGET_SOURCES(time_stepping PRIVATE VCTwoFluidStaggeredStokesOperator.cpp VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp FullFACPreconditioner.cpp RBGS.f INSVCTwoFluidStaggeredHierarchyIntegrator.cpp)
 TARGET_LINK_LIBRARIES(time_stepping IBAMR::IBAMR2d)
 
+ADD_EXECUTABLE(four_roll_mill four_roll_mill.cpp)
+TARGET_SOURCES(four_roll_mill PRIVATE VCTwoFluidStaggeredStokesOperator.cpp VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp FullFACPreconditioner.cpp RBGS.f INSVCTwoFluidStaggeredHierarchyIntegrator.cpp)
+TARGET_LINK_LIBRARIES(four_roll_mill IBAMR::IBAMR2d)
+
 ADD_SUBDIRECTORY(tests)

--- a/FullFACPreconditioner.h
+++ b/FullFACPreconditioner.h
@@ -192,6 +192,14 @@ public:
         return d_dense_hierarchy;
     }
 
+    /*!
+     * Allocate and transfer data from the base hierarchy given to the object via initializeOperatorState() to the dense
+     * hierarchy owned by this object. If specified, this will also deallocate data from the dense hierarchy when
+     * deallocateSolverState() is called.
+     */
+    void transferToDense(int idx, bool deallocate_data = true);
+    void transferToDense(std::set<int> idxs, bool deallocate_data = true);
+
 protected:
 private:
     int d_multigrid_max_levels = -1;
@@ -237,6 +245,8 @@ private:
 
     std::map<SAMRAI::hier::Variable<NDIM>*, SAMRAI::tbox::Pointer<SAMRAI::math::HierarchyDataOpsReal<NDIM, double>>>
         d_var_op_map;
+
+    std::set<int> d_allocated_idxs;
 };
 } // namespace IBTK
 

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -121,13 +121,41 @@
 
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 
+namespace
+{
+// Copy data from a side-centered variable to a face-centered variable.
+void
+copy_side_to_face(const int u_fc_idx, const int u_sc_idx, Pointer<PatchHierarchy<NDIM>> hierarchy)
+{
+    const int coarsest_ln = 0;
+    const int finest_ln = hierarchy->getFinestLevelNumber();
+    for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+    {
+        Pointer<PatchLevel<NDIM>> level = hierarchy->getPatchLevel(ln);
+        for (PatchLevel<NDIM>::Iterator p(level); p; p++)
+        {
+            Pointer<Patch<NDIM>> patch = level->getPatch(p());
+            Pointer<FaceData<NDIM, double>> u_f_data = patch->getPatchData(u_fc_idx);
+            Pointer<SideData<NDIM, double>> u_s_data = patch->getPatchData(u_sc_idx);
+            const Box<NDIM> box = patch->getBox();
+            for (int axis = 0; axis < NDIM; ++axis)
+            {
+                for (SideIterator<NDIM> i(box, axis); i; i++)
+                {
+                    const SideIndex<NDIM>& si = i();
+                    FaceIndex<NDIM> fi(si.toCell(0), axis, 1);
+                    (*u_f_data)(fi) = (*u_s_data)(si);
+                }
+            }
+        }
+    }
+
+    return;
+} // copy_side_to_face
+} // namespace
+
 namespace IBAMR
 {
-static double
-convertToThs(const double thn)
-{
-    return 1.0 - thn;
-}
 
 /////////////////////////////// PUBLIC ///////////////////////////////////////
 INSVCTwoFluidStaggeredHierarchyIntegrator::INSVCTwoFluidStaggeredHierarchyIntegrator(
@@ -229,11 +257,34 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::setForcingFunctions(Pointer<CartGridF
 }
 
 void
-INSVCTwoFluidStaggeredHierarchyIntegrator::setNetworkVolumeFractionFunction(Pointer<CartGridFunction> thn_fcn)
+INSVCTwoFluidStaggeredHierarchyIntegrator::setInitialNetworkVolumeFraction(Pointer<CartGridFunction> thn_init_fcn)
+{
+    d_thn_init_fcn = thn_init_fcn;
+}
+
+void
+INSVCTwoFluidStaggeredHierarchyIntegrator::setNetworkVolumeFractionFunction(Pointer<CartGridFunction> thn_fcn,
+                                                                            bool use_as_initial_data)
 {
     // Make sure we have a valid pointer.
     TBOX_ASSERT(thn_fcn);
     d_thn_fcn = thn_fcn;
+    if (use_as_initial_data) d_thn_init_fcn = thn_fcn;
+}
+
+void
+INSVCTwoFluidStaggeredHierarchyIntegrator::advectNetworkVolumeFraction(
+    Pointer<AdvDiffHierarchyIntegrator> adv_diff_integrator)
+{
+    registerAdvDiffHierarchyIntegrator(adv_diff_integrator);
+    d_thn_integrator = adv_diff_integrator;
+
+    // Set up thn to be advected
+    d_thn_cc_var = new CellVariable<NDIM, double>(d_object_name + "::thn_cc");
+    d_thn_integrator->registerTransportedQuantity(d_thn_cc_var, true /*output_Q*/);
+    d_thn_integrator->setAdvectionVelocity(d_thn_cc_var, d_U_adv_diff_var);
+    d_thn_integrator->setAdvectionVelocityIsDivergenceFree(d_U_adv_diff_var, false); // Not divergence free in general.
+    d_thn_integrator->setInitialConditions(d_thn_cc_var, d_thn_init_fcn);
 }
 
 void
@@ -248,13 +299,14 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer
 
     // First create the variables we need.
     // NOTE: d_P_var is a member variable of the base class.
-    d_un_sc_var = new SideVariable<NDIM, double>(d_object_name + "un_sc");
-    d_us_sc_var = new SideVariable<NDIM, double>(d_object_name + "us_sc");
-    d_thn_cc_var = new CellVariable<NDIM, double>(d_object_name + "thn_cc");
+    d_un_sc_var = new SideVariable<NDIM, double>(d_object_name + "::un_sc");
+    d_us_sc_var = new SideVariable<NDIM, double>(d_object_name + "::us_sc");
+    // NOTE: This may have been created above with the advection diffusion integrator.
+    if (!d_thn_cc_var) d_thn_cc_var = new CellVariable<NDIM, double>(d_object_name + "::thn_cc");
     d_grad_thn_var = new CellVariable<NDIM, double>(d_object_name + "grad_thn_cc", NDIM);
-    d_f_un_sc_var = new SideVariable<NDIM, double>(d_object_name + "f_un_sc");
-    d_f_us_sc_var = new SideVariable<NDIM, double>(d_object_name + "f_us_sc");
-    d_f_cc_var = new CellVariable<NDIM, double>(d_object_name + "f_cc");
+    d_f_un_sc_var = new SideVariable<NDIM, double>(d_object_name + "::f_un_sc");
+    d_f_us_sc_var = new SideVariable<NDIM, double>(d_object_name + "::f_us_sc");
+    d_f_cc_var = new CellVariable<NDIM, double>(d_object_name + "::f_cc");
 
     // Register variables with the integrator. Those with states (Velocities) have associated current, new, and scratch
     // indices. NOTE: Pressure is NOT a state variable, but we keep track of current and new values for initial guesses
@@ -289,11 +341,12 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer
 
     // Everything else only gets a scratch context, which is deallocated at the end of each time step.
     // Note the forces need ghost cells for modifying the RHS to account for non-homogenous boundary conditions.
-    int thn_idx, f_p_idx, f_un_idx, f_us_idx;
-    registerVariable(thn_idx, d_thn_cc_var, IntVector<NDIM>(1), getScratchContext());
+    int thn_cur_idx, thn_new_idx, f_p_idx, f_un_idx, f_us_idx;
     registerVariable(f_p_idx, d_f_cc_var, IntVector<NDIM>(1), getScratchContext());
     registerVariable(f_un_idx, d_f_un_sc_var, IntVector<NDIM>(1), getScratchContext());
     registerVariable(f_us_idx, d_f_us_sc_var, IntVector<NDIM>(1), getScratchContext());
+    registerVariable(thn_cur_idx, d_thn_cc_var, IntVector<NDIM>(1), getCurrentContext());
+    registerVariable(thn_new_idx, d_thn_cc_var, IntVector<NDIM>(1), getNewContext());
 
     // Register gradient of thn with the current context
     int grad_thn_idx;
@@ -320,7 +373,11 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer
         for (int d = 0; d < NDIM; ++d)
             d_visit_writer->registerPlotQuantity("Us_" + std::to_string(d), "SCALAR", us_draw_idx, d, 1.0, "NODE");
 
-        d_visit_writer->registerPlotQuantity("P", "SCALAR", p_cur_idx, 0, 1.0, "NODE");
+        d_visit_writer->registerPlotQuantity("P", "SCALAR", p_cur_idx, 0, 1.0, "CELL");
+
+        // Only need to plot this variable if we aren't advecting it.
+        // If we do advect theta, the advection integrator will plot it.
+        if (d_thn_fcn) d_visit_writer->registerPlotQuantity("Thn", "SCALAR", thn_cur_idx, 0, 1.0, "CELL");
     }
 
     // Create the hierarchy data operations
@@ -329,6 +386,8 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::initializeHierarchyIntegrator(Pointer
         hier_ops_manager->getOperationsDouble(new CellVariable<NDIM, double>("cc_var"), hierarchy, true /*get_unique*/);
     d_hier_sc_data_ops =
         hier_ops_manager->getOperationsDouble(new SideVariable<NDIM, double>("sc_var"), hierarchy, true /*get_unique*/);
+    d_hier_fc_data_ops =
+        hier_ops_manager->getOperationsDouble(new FaceVariable<NDIM, double>("fc_var"), hierarchy, true /*get_unique*/);
 
     d_integrator_is_initialized = true;
     return;
@@ -409,6 +468,9 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::resetHierarchyConfigurationSpecialize
 
     d_hier_sc_data_ops->setPatchHierarchy(hierarchy);
     d_hier_sc_data_ops->resetLevels(coarsest_level, finest_level);
+
+    d_hier_fc_data_ops->setPatchHierarchy(hierarchy);
+    d_hier_fc_data_ops->resetLevels(coarsest_level, finest_level);
 }
 
 void
@@ -471,11 +533,24 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     d_rhs_vec->addComponent(d_f_cc_var, f_p_idx, wgt_cc_idx, d_hier_cc_data_ops);
 
     // Grab the theta index
-    const int thn_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getScratchContext());
-    // Set the correct data if applicable
+    const int thn_cur_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getCurrentContext());
+    const int thn_new_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getNewContext());
     if (d_thn_fcn)
+    {
+        // Set the correct data if applicable
         d_thn_fcn->setDataOnPatchHierarchy(
-            thn_idx, d_thn_cc_var, d_hierarchy, current_time, false, coarsest_ln, finest_ln);
+            thn_cur_idx, d_thn_cc_var, d_hierarchy, current_time, false, coarsest_ln, finest_ln);
+        d_thn_fcn->setDataOnPatchHierarchy(
+            thn_new_idx, d_thn_cc_var, d_hierarchy, new_time, false, coarsest_ln, finest_ln);
+    }
+    else
+    {
+        const int thn_adv_cur_idx =
+            var_db->mapVariableAndContextToIndex(d_thn_cc_var, d_thn_integrator->getCurrentContext());
+        // Otherwise set the new data to the best guess
+        d_hier_cc_data_ops->copyData(thn_new_idx, thn_adv_cur_idx);
+        d_hier_cc_data_ops->copyData(thn_cur_idx, thn_adv_cur_idx);
+    }
 
     // Set up null vectors (if applicable)
     d_nul_vecs.resize(1);
@@ -527,7 +602,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     RHS_op.setCandDCoefficients(C, D1);
     RHS_op.setDragCoefficient(1.0, 1.0, 1.0);
     RHS_op.setViscosityCoefficient(1.0, 1.0);
-    RHS_op.setThnIdx(thn_idx);
+    RHS_op.setThnIdx(thn_cur_idx); // Values at time t_n
 
     // Store results of applying stokes operator in f2_vec
     Pointer<SAMRAIVectorReal<NDIM, double>> f2_vec = d_rhs_vec->cloneVector("f2_vec");
@@ -546,7 +621,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     d_stokes_op->setCandDCoefficients(C, D2);
     d_stokes_op->setDragCoefficient(1.0, 1.0, 1.0);
     d_stokes_op->setViscosityCoefficient(1.0, 1.0);
-    d_stokes_op->setThnIdx(thn_idx);
+    d_stokes_op->setThnIdx(thn_new_idx); // Approximation at time t_{n+1}
 
     d_stokes_solver = new PETScKrylovLinearSolver("solver", d_solver_db, "solver_");
     d_stokes_solver->setOperator(d_stokes_op);
@@ -556,7 +631,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     {
         d_precond_op = new VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(
             "KrylovPrecondStrategy", "Krylov_precond_", d_w, C, D2);
-        d_precond_op->setThnIdx(thn_idx);
+        d_precond_op->setThnIdx(thn_new_idx); // Approximation at time t_{n+1}
         d_stokes_precond = new FullFACPreconditioner("KrylovPrecond", d_precond_op, d_precond_db, "Krylov_precond_");
         d_stokes_precond->setNullspace(false, d_nul_vecs);
         d_stokes_solver->setPreconditioner(d_stokes_precond);
@@ -569,30 +644,58 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     if (d_use_preconditioner)
     {
         Pointer<PatchHierarchy<NDIM>> dense_hierarchy = d_stokes_precond->getDenseHierarchy();
-        // Allocate data
-        for (int ln = 0; ln <= dense_hierarchy->getFinestLevelNumber(); ++ln)
+        if (d_thn_fcn)
         {
-            Pointer<PatchLevel<NDIM>> level = dense_hierarchy->getPatchLevel(ln);
-            if (!level->checkAllocated(thn_idx)) level->allocatePatchData(thn_idx, new_time);
+            // Allocate data
+            for (int ln = 0; ln <= dense_hierarchy->getFinestLevelNumber(); ++ln)
+            {
+                Pointer<PatchLevel<NDIM>> level = dense_hierarchy->getPatchLevel(ln);
+                if (!level->checkAllocated(thn_new_idx)) level->allocatePatchData(thn_new_idx, new_time);
+            }
+            d_thn_fcn->setDataOnPatchHierarchy(thn_new_idx,
+                                               d_thn_cc_var,
+                                               dense_hierarchy,
+                                               new_time,
+                                               false,
+                                               0,
+                                               dense_hierarchy->getFinestLevelNumber());
         }
-        d_thn_fcn->setDataOnPatchHierarchy(
-            thn_idx, d_thn_cc_var, dense_hierarchy, new_time, false, 0, dense_hierarchy->getFinestLevelNumber());
+        else
         {
-            // Also fill in theta ghost cells
-            using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
-            std::vector<ITC> ghost_cell_comp(1);
-            ghost_cell_comp[0] = ITC(thn_idx,
-                                     "CONSERVATIVE_LINEAR_REFINE",
-                                     false,
-                                     "NONE",
-                                     "LINEAR",
-                                     true,
-                                     nullptr); // defaults to fill corner
-            HierarchyGhostCellInterpolation ghost_cell_fill;
-            ghost_cell_fill.initializeOperatorState(
-                ghost_cell_comp, dense_hierarchy, 0, dense_hierarchy->getFinestLevelNumber());
-            ghost_cell_fill.fillData(0.0);
+            d_stokes_precond->transferToDense(thn_new_idx, true);
         }
+
+        // Also fill in ghost cells on the dense hierarchy
+        using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
+        std::vector<ITC> ghost_cell_comp(1);
+        ghost_cell_comp[0] = ITC(thn_new_idx,
+                                 "CONSERVATIVE_LINEAR_REFINE",
+                                 false,
+                                 "NONE",
+                                 "LINEAR",
+                                 true,
+                                 nullptr); // defaults to fill corner
+        HierarchyGhostCellInterpolation ghost_cell_fill;
+        ghost_cell_fill.initializeOperatorState(
+            ghost_cell_comp, dense_hierarchy, 0, dense_hierarchy->getFinestLevelNumber());
+        ghost_cell_fill.fillData(0.0);
+    }
+
+    // Set up the advection diffusion integrator
+    for (const auto& adv_diff_integrator : d_adv_diff_hier_integrators)
+    {
+        const int U_adv_diff_cur_idx =
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_integrator->getCurrentContext());
+        const int U_adv_diff_scr_idx =
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_integrator->getScratchContext());
+        const int U_adv_diff_new_idx =
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_integrator->getNewContext());
+        if (isAllocatedPatchData(U_adv_diff_cur_idx)) copy_side_to_face(U_adv_diff_cur_idx, un_cur_idx, d_hierarchy);
+        adv_diff_integrator->preprocessIntegrateHierarchy(current_time, new_time, num_cycles);
+        if (isAllocatedPatchData(U_adv_diff_scr_idx))
+            d_hier_fc_data_ops->copyData(U_adv_diff_scr_idx, U_adv_diff_cur_idx);
+        if (isAllocatedPatchData(U_adv_diff_new_idx))
+            d_hier_fc_data_ops->copyData(U_adv_diff_new_idx, U_adv_diff_cur_idx);
     }
 
     executePreprocessIntegrateHierarchyCallbackFcns(current_time, new_time, num_cycles);
@@ -609,6 +712,39 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::integrateHierarchy(const double curre
     const int un_new_idx = var_db->mapVariableAndContextToIndex(d_un_sc_var, getNewContext());
     const int us_new_idx = var_db->mapVariableAndContextToIndex(d_us_sc_var, getNewContext());
     const int p_new_idx = var_db->mapVariableAndContextToIndex(d_P_var, getNewContext());
+    // Update the state of the advection diffusion integrator
+    for (const auto& adv_diff_integrator : d_adv_diff_hier_integrators)
+        adv_diff_integrator->integrateHierarchy(current_time, new_time, cycle_num);
+
+    // Update thn if necessary. We need to update it if we are using the preconditioner, which uses a different patch
+    // hierarchy.
+    if (d_thn_integrator)
+    {
+        const int thn_new_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getNewContext());
+        const int thn_adv_new_idx =
+            var_db->mapVariableAndContextToIndex(d_thn_cc_var, d_thn_integrator->getNewContext());
+        d_hier_cc_data_ops->copyData(thn_new_idx, thn_adv_new_idx);
+        if (d_use_preconditioner)
+        {
+            d_stokes_precond->transferToDense(thn_new_idx);
+            // Also fill in ghost cells on the dense hierarchy
+            Pointer<PatchHierarchy<NDIM>> dense_hierarchy = d_stokes_precond->getDenseHierarchy();
+            using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
+            std::vector<ITC> ghost_cell_comp(1);
+            ghost_cell_comp[0] = ITC(thn_new_idx,
+                                     "CONSERVATIVE_LINEAR_REFINE",
+                                     false,
+                                     "NONE",
+                                     "LINEAR",
+                                     true,
+                                     nullptr); // defaults to fill corner
+            HierarchyGhostCellInterpolation ghost_cell_fill;
+            ghost_cell_fill.initializeOperatorState(
+                ghost_cell_comp, dense_hierarchy, 0, dense_hierarchy->getFinestLevelNumber());
+            ghost_cell_fill.fillData(0.0);
+        }
+    }
+    const double dt = new_time - current_time;
 
     // Set the initial guess for the system to be the most recent approximation to t^{n+1}
     d_hier_sc_data_ops->copyData(d_sol_vec->getComponentDescriptorIndex(0), un_new_idx);
@@ -622,6 +758,32 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::integrateHierarchy(const double curre
     d_hier_sc_data_ops->copyData(un_new_idx, d_sol_vec->getComponentDescriptorIndex(0));
     d_hier_sc_data_ops->copyData(us_new_idx, d_sol_vec->getComponentDescriptorIndex(1));
     d_hier_cc_data_ops->copyData(p_new_idx, d_sol_vec->getComponentDescriptorIndex(2));
+
+    // Do any more updates to the advection diffusion variables
+    for (const auto& adv_diff_hier_integrator : d_adv_diff_hier_integrators)
+    {
+        // Reset the velocities
+        const int U_adv_diff_new_idx =
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getNewContext());
+        if (isAllocatedPatchData(U_adv_diff_new_idx)) copy_side_to_face(U_adv_diff_new_idx, un_new_idx, d_hierarchy);
+        const int U_adv_diff_cur_idx =
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getCurrentContext());
+        const int U_adv_diff_scr_idx =
+            var_db->mapVariableAndContextToIndex(d_U_adv_diff_var, adv_diff_hier_integrator->getScratchContext());
+        if (isAllocatedPatchData(U_adv_diff_scr_idx))
+            d_hier_fc_data_ops->linearSum(U_adv_diff_scr_idx, 0.5, U_adv_diff_new_idx, 0.5, U_adv_diff_cur_idx);
+
+        // Now update the state variables. Note that cycle 0 has already been performed
+        const int adv_diff_num_cycles = adv_diff_hier_integrator->getNumberOfCycles();
+        if (d_current_num_cycles != adv_diff_num_cycles)
+        {
+            for (int adv_diff_cycle_num = 1; adv_diff_cycle_num < adv_diff_num_cycles; ++adv_diff_cycle_num)
+                adv_diff_hier_integrator->integrateHierarchy(current_time, new_time, adv_diff_cycle_num);
+        }
+    }
+
+    // Execuate any registered callbacks
+    executeIntegrateHierarchyCallbackFcns(current_time, new_time, cycle_num);
     return;
 } // integrateHierarchy
 
@@ -655,18 +817,16 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const d
     // TODO: Replace this with a max over the L2 norm.
     d_max_grad_thn = d_hier_cc_data_ops->maxNorm(grad_thn_idx, IBTK::invalid_index);
 
-    // Deallocate patch data on the dense hierarchy
-    if (d_use_preconditioner)
+    // Synchronize new state
+    if (!skip_synchronize_new_state_data) synchronizeHierarchyData(NEW_DATA);
+
+    // Note: Preconditioner should deallocate data as necessary.
+    // Deallocate scratch data
+    for (const auto& adv_diff_hier_integrator : d_adv_diff_hier_integrators)
     {
-        auto var_db = VariableDatabase<NDIM>::getDatabase();
-        const int thn_cc_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getScratchContext());
-        Pointer<PatchHierarchy<NDIM>> dense_hierarchy = d_stokes_precond->getDenseHierarchy();
-        for (int ln = 0; ln <= dense_hierarchy->getFinestLevelNumber(); ++ln)
-        {
-            Pointer<PatchLevel<NDIM>> level = dense_hierarchy->getPatchLevel(ln);
-            if (level->checkAllocated(thn_cc_idx)) level->deallocatePatchData(thn_cc_idx);
-            // deallocate the gradient thn patch data here?
-        }
+        const int adv_diff_num_cycles = adv_diff_hier_integrator->getNumberOfCycles();
+        adv_diff_hier_integrator->postprocessIntegrateHierarchy(
+            current_time, new_time, skip_synchronize_new_state_data, adv_diff_num_cycles);
     }
 
     for (auto& nul_vec : d_nul_vecs)
@@ -717,6 +877,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::setupPlotDataSpecialized()
     const int us_idx = var_db->mapVariableAndContextToIndex(d_us_sc_var, getCurrentContext());
     const int un_scr_idx = var_db->mapVariableAndContextToIndex(d_un_sc_var, getScratchContext());
     const int us_scr_idx = var_db->mapVariableAndContextToIndex(d_us_sc_var, getScratchContext());
+    const int thn_cur_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getCurrentContext());
 
     static const bool synch_cf_interface = true;
     const int coarsest_ln = 0;
@@ -753,6 +914,11 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::setupPlotDataSpecialized()
                             nullptr,
                             d_integrator_time,
                             synch_cf_interface);
+
+    // Set thn if necessary
+    if (d_thn_fcn)
+        d_thn_fcn->setDataOnPatchHierarchy(
+            thn_cur_idx, d_thn_cc_var, d_hierarchy, d_integrator_time, false, coarsest_ln, finest_ln);
 
     // Deallocate scratch data
     deallocatePatchData(un_scr_idx, coarsest_ln, finest_ln);

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -819,7 +819,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const d
     // Calculate gradient of thn for grid cell tagging.
     auto var_db = VariableDatabase<NDIM>::getDatabase();
     const int grad_thn_idx = var_db->mapVariableAndContextToIndex(d_grad_thn_var, getCurrentContext());
-    const int thn_new_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getScratchContext());
+    const int thn_new_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getNewContext());
     using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
     std::vector<ITC> ghost_cell_comp(1);
     ghost_cell_comp[0] = ITC(thn_new_idx, "CONSERVATIVE_LINEAR_REFINE", false, "NONE", "LINEAR", false, nullptr);

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -235,6 +235,21 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::getPressureVariable() const
 }
 
 void
+INSVCTwoFluidStaggeredHierarchyIntegrator::setViscosityCoefficient(const double eta_n, const double eta_s)
+{
+    d_eta_n = eta_n;
+    d_eta_s = eta_s;
+}
+
+void
+INSVCTwoFluidStaggeredHierarchyIntegrator::setDragCoefficient(const double xi, const double nu_n, const double nu_s)
+{
+    d_xi = xi;
+    d_nu_n = nu_n;
+    d_nu_s = nu_s;
+}
+
+void
 INSVCTwoFluidStaggeredHierarchyIntegrator::setInitialData(Pointer<CartGridFunction> un_fcn,
                                                           Pointer<CartGridFunction> us_fcn,
                                                           Pointer<CartGridFunction> p_fcn)
@@ -600,8 +615,8 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
 
     VCTwoFluidStaggeredStokesOperator RHS_op("RHS_op", true);
     RHS_op.setCandDCoefficients(C, D1);
-    RHS_op.setDragCoefficient(1.0, 1.0, 1.0);
-    RHS_op.setViscosityCoefficient(1.0, 1.0);
+    RHS_op.setDragCoefficient(d_xi, d_nu_n, d_nu_s);
+    RHS_op.setViscosityCoefficient(d_eta_n, d_eta_s);
     RHS_op.setThnIdx(thn_cur_idx); // Values at time t_n
 
     // Store results of applying stokes operator in f2_vec
@@ -619,8 +634,8 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     // Set up the operators and solvers needed to solve the linear system.
     d_stokes_op = new VCTwoFluidStaggeredStokesOperator("stokes_op", true);
     d_stokes_op->setCandDCoefficients(C, D2);
-    d_stokes_op->setDragCoefficient(1.0, 1.0, 1.0);
-    d_stokes_op->setViscosityCoefficient(1.0, 1.0);
+    d_stokes_op->setDragCoefficient(d_xi, d_nu_n, d_nu_s);
+    d_stokes_op->setViscosityCoefficient(d_eta_n, d_eta_s);
     d_stokes_op->setThnIdx(thn_new_idx); // Approximation at time t_{n+1}
 
     d_stokes_solver = new PETScKrylovLinearSolver("solver", d_solver_db, "solver_");
@@ -629,9 +644,13 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     // Now create a preconditioner
     if (d_use_preconditioner)
     {
-        d_precond_op = new VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(
-            "KrylovPrecondStrategy", "Krylov_precond_", d_w, C, D2);
+        d_precond_op =
+            new VCTwoFluidStaggeredStokesBoxRelaxationFACOperator("KrylovPrecondStrategy", "Krylov_precond_");
         d_precond_op->setThnIdx(thn_new_idx); // Approximation at time t_{n+1}
+        d_precond_op->setDragCoefficient(d_xi, d_nu_n, d_nu_s);
+        d_precond_op->setViscosityCoefficient(d_eta_n, d_eta_s);
+        d_precond_op->setUnderRelaxationParamater(d_w);
+        d_precond_op->setCandDCoefficients(C, D2);
         d_stokes_precond = new FullFACPreconditioner("KrylovPrecond", d_precond_op, d_precond_db, "Krylov_precond_");
         d_stokes_precond->setNullspace(false, d_nul_vecs);
         d_stokes_solver->setPreconditioner(d_stokes_precond);

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.h
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.h
@@ -109,6 +109,16 @@ public:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> getPressureVariable() const;
 
     /*!
+     * \brief Set the viscosity coefficients for the viscous stresses.
+     */
+    void setViscosityCoefficient(double eta_n, double eta_s);
+
+    /*!
+     * \brief Set the drag coefficients for each phase.
+     */
+    void setDragCoefficient(double xi, double nu_n, double nu_s);
+
+    /*!
      * Set initial conditions for the state variables.
      *
      * NOTE: These pointers are set to nullptr after they are used.
@@ -275,8 +285,11 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>> d_rhs_vec;
     std::vector<SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>>> d_nul_vecs;
 
-    // Density
+    // Physical parameters
     double d_rho = std::numeric_limits<double>::quiet_NaN();
+    double d_xi = std::numeric_limits<double>::quiet_NaN(), d_nu_n = std::numeric_limits<double>::quiet_NaN(),
+           d_nu_s = std::numeric_limits<double>::quiet_NaN();
+    double d_eta_n = std::numeric_limits<double>::quiet_NaN(), d_eta_s = std::numeric_limits<double>::quiet_NaN();
 
     /*!
      * Solver information

--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.h
@@ -51,10 +51,7 @@ public:
      * \param C scaler-valued C in C*u term used to add diagonal dominance
      */
     VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(const std::string& object_name,
-                                                      const std::string& default_options_prefix,
-                                                      double w,
-                                                      double C,
-                                                      double D);
+                                                      const std::string& default_options_prefix);
 
     /*!
      * \brief Destructor.
@@ -172,22 +169,25 @@ public:
      */
     void deallocateOperatorState() override;
 
-protected:
-    int d_thn_idx = IBTK::invalid_index;
-    int d_un_scr_idx = IBTK::invalid_index, d_us_scr_idx = IBTK::invalid_index, d_p_scr_idx = IBTK::invalid_index;
-    double d_w = std::numeric_limits<double>::quiet_NaN(); // under relaxation factor
-    double d_C = std::numeric_limits<double>::quiet_NaN(); // C*u
-    double d_D = std::numeric_limits<double>::quiet_NaN(); // D depends on time stepping scheme
+    /*!
+     * \brief Set the under relaxation parameter.
+     */
+    void setUnderRelaxationParamater(double w);
 
-    SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> d_hierarchy; // Reference patch hierarchy
-    std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_un_bc_coefs;
-    std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_us_bc_coefs;
-    SAMRAI::solv::RobinBcCoefStrategy<NDIM>* d_P_bc_coef = nullptr;
-    // Cached communications operators.
-    SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM>> d_un_fill_pattern, d_us_fill_pattern,
-        d_P_fill_pattern;
-    std::vector<IBTK::HierarchyGhostCellInterpolation::InterpolationTransactionComponent> transaction_comps;
-    SAMRAI::tbox::Pointer<IBTK::HierarchyGhostCellInterpolation> d_hier_bdry_fill, d_no_fill;
+    /*!
+     * \brief Set the C and D coefficients.
+     */
+    void setCandDCoefficients(double C, double D);
+
+    /*!
+     * \brief Set the viscosity coefficients for the viscous stresses.
+     */
+    void setViscosityCoefficient(double eta_n, double eta_s);
+
+    /*!
+     * \brief Set the drag coefficients for each phase.
+     */
+    void setDragCoefficient(double xi, double nu_n, double nu_s);
 
 private:
     /*!
@@ -259,6 +259,27 @@ private:
     std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM>>> d_prolong_scheds;
     std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::CoarsenSchedule<NDIM>>> d_restrict_scheds;
     std::vector<SAMRAI::tbox::Pointer<SAMRAI::xfer::RefineSchedule<NDIM>>> d_ghostfill_no_restrict_scheds;
+
+    int d_thn_idx = IBTK::invalid_index;
+    int d_un_scr_idx = IBTK::invalid_index, d_us_scr_idx = IBTK::invalid_index, d_p_scr_idx = IBTK::invalid_index;
+    double d_w = 0.75;                                         // under relaxation factor
+    double d_C = std::numeric_limits<double>::quiet_NaN();     // C*u
+    double d_D = std::numeric_limits<double>::quiet_NaN();     // D depends on time stepping scheme
+    double d_eta_n = std::numeric_limits<double>::quiet_NaN(); // Network viscosity
+    double d_eta_s = std::numeric_limits<double>::quiet_NaN(); // Solvent viscosity
+    double d_xi = std::numeric_limits<double>::quiet_NaN();    // Drag coefficient
+    double d_nu_n = std::numeric_limits<double>::quiet_NaN();
+    double d_nu_s = std::numeric_limits<double>::quiet_NaN();
+
+    SAMRAI::tbox::Pointer<SAMRAI::hier::PatchHierarchy<NDIM>> d_hierarchy; // Reference patch hierarchy
+    std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_un_bc_coefs;
+    std::vector<SAMRAI::solv::RobinBcCoefStrategy<NDIM>*> d_us_bc_coefs;
+    SAMRAI::solv::RobinBcCoefStrategy<NDIM>* d_P_bc_coef = nullptr;
+    // Cached communications operators.
+    SAMRAI::tbox::Pointer<SAMRAI::xfer::VariableFillPattern<NDIM>> d_un_fill_pattern, d_us_fill_pattern,
+        d_P_fill_pattern;
+    std::vector<IBTK::HierarchyGhostCellInterpolation::InterpolationTransactionComponent> transaction_comps;
+    SAMRAI::tbox::Pointer<IBTK::HierarchyGhostCellInterpolation> d_hier_bdry_fill, d_no_fill;
 };
 } // namespace IBTK
 

--- a/four_roll_mill.cpp
+++ b/four_roll_mill.cpp
@@ -1,0 +1,251 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2017 - 2020 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include <ibamr/AdvDiffSemiImplicitHierarchyIntegrator.h>
+#include <ibamr/StaggeredStokesSolverManager.h>
+#include <ibamr/StokesSpecifications.h>
+#include <ibamr/app_namespaces.h>
+
+#include "ibtk/CartCellDoubleQuadraticRefine.h"
+#include "ibtk/CartSideDoubleRT0Refine.h"
+#include "ibtk/PETScKrylovLinearSolver.h"
+#include <ibtk/AppInitializer.h>
+#include <ibtk/IBTKInit.h>
+#include <ibtk/LinearOperator.h>
+#include <ibtk/muParserCartGridFunction.h>
+#include <ibtk/muParserRobinBcCoefs.h>
+
+#include <petscsys.h>
+
+#include <BergerRigoutsos.h>
+#include <CartesianGridGeometry.h>
+#include <GriddingAlgorithm.h>
+#include <LoadBalancer.h>
+#include <SAMRAI_config.h>
+#include <StandardTagAndInitialize.h>
+
+// Local includes
+#include "INSVCTwoFluidStaggeredHierarchyIntegrator.h"
+
+/*******************************************************************************
+ * For each run, the input filename must be given on the command line.  In all *
+ * cases, the command line is:                                                 *
+ *                                                                             *
+ *    executable <input file name>                                             *
+ *                                                                             *
+ *******************************************************************************/
+int
+main(int argc, char* argv[])
+{
+    // Initialize IBAMR and libraries. Deinitialization is handled by this object as well.
+    IBTKInit ibtk_init(argc, argv, MPI_COMM_WORLD);
+
+    { // cleanup dynamically allocated objects prior to shutdown
+
+        // Parse command line options, set some standard options from the input
+        // file, and enable file logging.
+        Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "stokes.log");
+        Pointer<Database> input_db = app_initializer->getInputDatabase();
+
+        // Create major algorithm and data objects that comprise the
+        // application.  These objects are configured from the input database.
+        Pointer<CartesianGridGeometry<NDIM>> grid_geometry = new CartesianGridGeometry<NDIM>(
+            "CartesianGeometry", app_initializer->getComponentDatabase("CartesianGeometry"));
+        Pointer<INSVCTwoFluidStaggeredHierarchyIntegrator> ins_integrator =
+            new INSVCTwoFluidStaggeredHierarchyIntegrator(
+                "FluidSolver",
+                app_initializer->getComponentDatabase("INSVCTwoFluidStaggeredHierarchyIntegrator"),
+                grid_geometry,
+                true /*register_for_restart*/);
+
+        Pointer<AdvDiffSemiImplicitHierarchyIntegrator> adv_diff_integrator =
+            new AdvDiffSemiImplicitHierarchyIntegrator("AdvDiffIntegrator",
+                                                       app_initializer->getComponentDatabase("AdvDiffIntegrator"),
+                                                       true /*register_for_restart*/);
+        grid_geometry->addSpatialRefineOperator(new CartCellDoubleQuadraticRefine()); // refine op for cell-centered
+                                                                                      // variables
+        grid_geometry->addSpatialRefineOperator(new CartSideDoubleRT0Refine()); // refine op for side-centered variables
+        Pointer<PatchHierarchy<NDIM>> patch_hierarchy = new PatchHierarchy<NDIM>("PatchHierarchy", grid_geometry);
+        Pointer<StandardTagAndInitialize<NDIM>> error_detector =
+            new StandardTagAndInitialize<NDIM>("StandardTagAndInitialize",
+                                               ins_integrator,
+                                               app_initializer->getComponentDatabase("StandardTagAndInitialize"));
+        Pointer<BergerRigoutsos<NDIM>> box_generator = new BergerRigoutsos<NDIM>();
+        Pointer<LoadBalancer<NDIM>> load_balancer =
+            new LoadBalancer<NDIM>("LoadBalancer", app_initializer->getComponentDatabase("LoadBalancer"));
+        Pointer<GriddingAlgorithm<NDIM>> gridding_algorithm =
+            new GriddingAlgorithm<NDIM>("GriddingAlgorithm",
+                                        app_initializer->getComponentDatabase("GriddingAlgorithm"),
+                                        error_detector,
+                                        box_generator,
+                                        load_balancer);
+
+        // Setup velocity and pressures functions.
+        Pointer<CartGridFunction> un_init =
+            new muParserCartGridFunction("un", app_initializer->getComponentDatabase("un"), grid_geometry);
+        Pointer<CartGridFunction> us_init =
+            new muParserCartGridFunction("us", app_initializer->getComponentDatabase("us"), grid_geometry);
+        Pointer<CartGridFunction> p_init =
+            new muParserCartGridFunction("p", app_initializer->getComponentDatabase("p"), grid_geometry);
+        ins_integrator->setInitialData(un_init, us_init, p_init);
+
+        // Set up Thn functions
+        Pointer<CartGridFunction> thn_init_fcn =
+            new muParserCartGridFunction("thn_init", app_initializer->getComponentDatabase("thn"), grid_geometry);
+        ins_integrator->setInitialNetworkVolumeFraction(thn_init_fcn);
+        ins_integrator->advectNetworkVolumeFraction(adv_diff_integrator);
+
+        // Set up forcing function
+        Pointer<CartGridFunction> fn_fcn =
+            new muParserCartGridFunction("f_un", app_initializer->getComponentDatabase("f_un"), grid_geometry);
+        Pointer<CartGridFunction> fs_fcn =
+            new muParserCartGridFunction("f_us", app_initializer->getComponentDatabase("f_us"), grid_geometry);
+        ins_integrator->setForcingFunctions(fn_fcn, fs_fcn, nullptr);
+
+        // Set up visualizations
+        Pointer<VisItDataWriter<NDIM>> visit_data_writer = app_initializer->getVisItDataWriter();
+        ins_integrator->registerVisItDataWriter(visit_data_writer);
+
+        // Initialize the INS integrator
+        ins_integrator->initializePatchHierarchy(patch_hierarchy, gridding_algorithm);
+
+        // Get some time stepping information.
+        unsigned int iteration_num = ins_integrator->getIntegratorStep();
+        double loop_time = ins_integrator->getIntegratorTime();
+        double time_end = ins_integrator->getEndTime();
+        double dt = 0.0;
+
+        // Visualization files info.
+        double viz_dump_time_interval = input_db->getDouble("VIZ_DUMP_TIME_INTERVAL");
+        double next_viz_dump_time = 0.0;
+        // At specified intervals, write visualization files
+        if (IBTK::abs_equal_eps(loop_time, next_viz_dump_time, 0.1 * dt) || loop_time >= next_viz_dump_time)
+        {
+            pout << "\nWriting visualization files...\n\n";
+            ins_integrator->setupPlotData();
+            visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+            next_viz_dump_time += viz_dump_time_interval;
+        }
+        // Main time step loop
+        while (!IBTK::rel_equal_eps(loop_time, time_end) && ins_integrator->stepsRemaining())
+        {
+            pout << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "At beginning of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+
+            dt = ins_integrator->getMaximumTimeStepSize();
+            ins_integrator->advanceHierarchy(dt);
+            loop_time += dt;
+
+            pout << "\n";
+            pout << "At end       of timestep # " << iteration_num << "\n";
+            pout << "Simulation time is " << loop_time << "\n";
+            pout << "+++++++++++++++++++++++++++++++++++++++++++++++++++\n";
+            pout << "\n";
+
+            iteration_num += 1;
+            // At specified intervals, write visualization files
+            if (IBTK::abs_equal_eps(loop_time, next_viz_dump_time, 0.1 * dt) || loop_time >= next_viz_dump_time)
+            {
+                pout << "\nWriting visualization files...\n\n";
+                ins_integrator->setupPlotData();
+                visit_data_writer->writePlotData(patch_hierarchy, iteration_num, loop_time);
+                next_viz_dump_time += viz_dump_time_interval;
+            }
+        }
+
+        // Compute errors.
+        Pointer<CartGridFunction> un_exact_fcn =
+            new muParserCartGridFunction("UN_exact", app_initializer->getComponentDatabase("un_exact"), grid_geometry);
+        Pointer<CartGridFunction> us_exact_fcn =
+            new muParserCartGridFunction("US_exact", app_initializer->getComponentDatabase("us_exact"), grid_geometry);
+        Pointer<CartGridFunction> p_exact_fcn =
+            new muParserCartGridFunction("P_exact", app_initializer->getComponentDatabase("p_exact"), grid_geometry);
+
+        // Get the current data.
+        Pointer<SideVariable<NDIM, double>> un_var = ins_integrator->getNetworkVariable();
+        Pointer<SideVariable<NDIM, double>> us_var = ins_integrator->getSolventVariable();
+        Pointer<CellVariable<NDIM, double>> p_var = ins_integrator->getPressureVariable();
+
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        Pointer<VariableContext> ctx = ins_integrator->getCurrentContext();
+        const int un_idx = var_db->mapVariableAndContextToIndex(un_var, ctx);
+        const int us_idx = var_db->mapVariableAndContextToIndex(us_var, ctx);
+        const int p_idx = var_db->mapVariableAndContextToIndex(p_var, ctx);
+
+        // Create scratch data.
+        Pointer<VariableContext> exa_ctx = var_db->getContext("Exact");
+        const int un_exa_idx = var_db->registerVariableAndContext(un_var, exa_ctx);
+        const int us_exa_idx = var_db->registerVariableAndContext(us_var, exa_ctx);
+        const int p_exa_idx = var_db->registerVariableAndContext(p_var, exa_ctx);
+
+        // Allocate scratch data
+        const int coarsest_ln = 0;
+        const int finest_ln = patch_hierarchy->getFinestLevelNumber();
+        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->allocatePatchData(un_exa_idx, loop_time);
+            level->allocatePatchData(us_exa_idx, loop_time);
+            level->allocatePatchData(p_exa_idx, loop_time);
+        }
+
+        // Fill in exact values
+        un_exact_fcn->setDataOnPatchHierarchy(
+            un_exa_idx, un_var, patch_hierarchy, loop_time, false, coarsest_ln, finest_ln);
+        us_exact_fcn->setDataOnPatchHierarchy(
+            us_exa_idx, us_var, patch_hierarchy, loop_time, false, coarsest_ln, finest_ln);
+        p_exact_fcn->setDataOnPatchHierarchy(
+            p_exa_idx, p_var, patch_hierarchy, loop_time, false, coarsest_ln, finest_ln);
+
+        HierarchyMathOps hier_math_ops("hier_math_ops", patch_hierarchy, coarsest_ln, finest_ln);
+        const int wgt_cc_idx = hier_math_ops.getCellWeightPatchDescriptorIndex();
+        const int wgt_sc_idx = hier_math_ops.getSideWeightPatchDescriptorIndex();
+        HierarchySideDataOpsReal<NDIM, double> hier_sc_data_ops(patch_hierarchy, coarsest_ln, finest_ln);
+        HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(patch_hierarchy, coarsest_ln, finest_ln);
+
+        // Compute error and print out norms.
+        hier_sc_data_ops.subtract(un_idx, un_idx, un_exa_idx);
+        hier_sc_data_ops.subtract(us_idx, us_idx, us_exa_idx);
+        hier_cc_data_ops.subtract(p_idx, p_idx, p_exa_idx);
+        pout << "Printing error norms\n\n";
+        pout << "Newtork velocity\n";
+        pout << "Un L1-norm:  " << hier_sc_data_ops.L1Norm(un_idx, wgt_sc_idx) << "\n";
+        pout << "Un L1-norm:  " << hier_sc_data_ops.L2Norm(un_idx, wgt_sc_idx) << "\n";
+        pout << "Un max-norm: " << hier_sc_data_ops.maxNorm(un_idx, wgt_sc_idx) << "\n\n";
+
+        pout << "Solvent velocity\n";
+        pout << "Us L1-norm:  " << hier_sc_data_ops.L1Norm(us_idx, wgt_sc_idx) << "\n";
+        pout << "Us L1-norm:  " << hier_sc_data_ops.L2Norm(us_idx, wgt_sc_idx) << "\n";
+        pout << "Us max-norm: " << hier_sc_data_ops.maxNorm(us_idx, wgt_sc_idx) << "\n\n";
+
+        pout << "Pressure\n";
+        pout << "P L1-norm:  " << hier_cc_data_ops.L1Norm(p_idx, wgt_cc_idx) << "\n";
+        pout << "P L1-norm:  " << hier_cc_data_ops.L2Norm(p_idx, wgt_cc_idx) << "\n";
+        pout << "P max-norm: " << hier_cc_data_ops.maxNorm(p_idx, wgt_cc_idx) << "\n";
+
+        // Print extra viz files for the error
+        pout << "\nWriting visualization files...\n\n";
+        ins_integrator->setupPlotData();
+        visit_data_writer->writePlotData(patch_hierarchy, iteration_num + 1, loop_time);
+
+        for (int ln = coarsest_ln; ln <= finest_ln; ++ln)
+        {
+            Pointer<PatchLevel<NDIM>> level = patch_hierarchy->getPatchLevel(ln);
+            level->deallocatePatchData(un_exa_idx);
+            level->deallocatePatchData(us_exa_idx);
+            level->deallocatePatchData(p_exa_idx);
+        }
+    } // cleanup dynamically allocated objects prior to shutdown
+} // main

--- a/four_roll_mill.cpp
+++ b/four_roll_mill.cpp
@@ -90,6 +90,9 @@ main(int argc, char* argv[])
                                         box_generator,
                                         load_balancer);
 
+        ins_integrator->setViscosityCoefficient(1.0, 1.0);
+        ins_integrator->setDragCoefficient(1.0, 1.0, 1.0);
+
         // Setup velocity and pressures functions.
         Pointer<CartGridFunction> un_init =
             new muParserCartGridFunction("un", app_initializer->getComponentDatabase("un"), grid_geometry);

--- a/four_roll_mill.cpp
+++ b/four_roll_mill.cpp
@@ -90,8 +90,8 @@ main(int argc, char* argv[])
                                         box_generator,
                                         load_balancer);
 
-        ins_integrator->setViscosityCoefficient(1.0, 1.0);
-        ins_integrator->setDragCoefficient(1.0, 1.0, 1.0);
+        ins_integrator->setViscosityCoefficient(0.04, 0.04);
+        ins_integrator->setDragCoefficient(250.0 * 0.04, 1.0, 1.0);
 
         // Setup velocity and pressures functions.
         Pointer<CartGridFunction> un_init =

--- a/input2d.four_roll_mill
+++ b/input2d.four_roll_mill
@@ -9,7 +9,7 @@ W = 0.75
 USE_PRECONDITIONER = TRUE
 N = 64
 VIZ_DUMP_TIME_INTERVAL = 0.01
-DELTA = 0.25
+DELTA = 0.175
 
 ADV_DIFF_NUM_CYCLES = 1
 ADV_DIFF_CONVECTIVE_OP_TYPE = "CUI"
@@ -42,7 +42,7 @@ f_us {
 
 thn {
    delta = DELTA
-   function = "0.25 + 0.5*((sqrt(X_0*X_0+X_1*X_1)<delta) ? (1989.0/(896*PI)*(1.0-((X_0*X_0+X_1*X_1)/(delta*delta))^4.0)^4.0*(4.0*((X_0*X_0+X_1*X_1)/(delta*delta))^4.0+1.0)) : 0.0)"
+   function = "0.05 + ((sqrt(X_0*X_0+X_1*X_1)<delta) ? (1989.0/(896*PI)*(1.0-((X_0*X_0+X_1*X_1)/(delta*delta))^4.0)^4.0*(4.0*((X_0*X_0+X_1*X_1)/(delta*delta))^4.0+1.0)) : 0.0)"
    //function = "0.5"
    //function = "0.25*sin(2*PI*X_0)*sin(2*PI*X_1) + 0.5"
 }
@@ -63,8 +63,8 @@ INSVCTwoFluidStaggeredHierarchyIntegrator {
 
    precond_db {
       cycle_type = "F_CYCLE"
-      num_pre_sweeps = 3
-      num_post_sweeps = 3
+      num_pre_sweeps = 18
+      num_post_sweeps = 18
       enable_logging = TRUE
       max_multigrid_levels = MAX_MULTIGRID_LEVELS
    }

--- a/input2d.four_roll_mill
+++ b/input2d.four_roll_mill
@@ -1,0 +1,149 @@
+RHO = 1.0
+MAX_MULTIGRID_LEVELS = 5
+START_TIME = 0.0
+END_TIME = 1.0
+NUM_CYCLES = 1
+DT_MAX = 0.005
+ENABLE_LOGGING = TRUE
+W = 0.75
+USE_PRECONDITIONER = TRUE
+N = 64
+VIZ_DUMP_TIME_INTERVAL = 0.01
+DELTA = 0.25
+
+ADV_DIFF_NUM_CYCLES = 1
+ADV_DIFF_CONVECTIVE_OP_TYPE = "CUI"
+ADV_DIFF_CONVECTIVE_TS_TYPE = "FORWARD_EULER"
+ADV_DIFF_CONVECTIVE_FORM = "CONSERVATIVE"
+
+un {
+   function_0 = "0.0"
+   function_1 = "0.0"
+}
+
+us {
+   function_0 = "0.0"
+   function_1 = "0.0"
+}
+
+p {
+   function = "0.0"
+} // pressure has mean 0
+
+f_un {
+   function_0 = "0.0"
+   function_1 = "0.0"
+}
+
+f_us {
+   function_0 = "(2.0*PI*sin(2.0*PI*X_0)*cos(2.0*PI*X_1) + 8*PI*PI*sin(2*PI*X_0)*cos(2*PI*X_1))"
+   function_1 = "(2.0*PI*cos(2.0*PI*X_0)*sin(2.0*PI*X_1) - 8*PI*PI*sin(2*PI*X_1)*cos(2*PI*X_0))"
+}
+
+thn {
+   delta = DELTA
+   function = "0.25 + 0.5*((sqrt(X_0*X_0+X_1*X_1)<delta) ? (1989.0/(896*PI)*(1.0-((X_0*X_0+X_1*X_1)/(delta*delta))^4.0)^4.0*(4.0*((X_0*X_0+X_1*X_1)/(delta*delta))^4.0+1.0)) : 0.0)"
+   //function = "0.5"
+   //function = "0.25*sin(2*PI*X_0)*sin(2*PI*X_1) + 0.5"
+}
+
+INSVCTwoFluidStaggeredHierarchyIntegrator {
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   num_cycles                    = NUM_CYCLES
+   dt_max                        = DT_MAX
+   enable_logging                = ENABLE_LOGGING
+   w = W
+   use_preconditioner = USE_PRECONDITIONER
+
+   solver_db {
+      ksp_type = "fgmres"
+   }
+
+   precond_db {
+      cycle_type = "F_CYCLE"
+      num_pre_sweeps = 3
+      num_post_sweeps = 3
+      enable_logging = TRUE
+      max_multigrid_levels = MAX_MULTIGRID_LEVELS
+   }
+}
+
+AdvDiffIntegrator {
+ start_time = START_TIME
+ end_time = END_TIME
+ num_cycles = ADV_DIFF_NUM_CYCLES
+ convective_time_stepping_type = ADV_DIFF_CONVECTIVE_TS_TYPE
+ convective_op_type = ADV_DIFF_CONVECTIVE_OP_TYPE
+ convective_difference_form = ADV_DIFF_CONVECTIVE_FORM
+ dt_max = DT_MAX
+ enable_logging = ENABLE_LOGGING
+}
+
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d_four_roll_mill"
+   visit_number_procs_per_file = 1
+
+// timer dump parameters
+   timer_enabled = TRUE
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = -0.5, -0.5      // lower end of computational domain.
+   x_up               = 0.5, 0.5      // upper end of computational domain.
+   periodic_dimension = 1, 1  
+}
+
+GriddingAlgorithm {
+   max_levels = 1                 // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 2, 2              // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 512, 512          // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4          // smallest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+    // level_0 = [( N/4 , N/4 ),( 3*N/4 - 1 , N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1, 3*N/4 - 2)]
+    // level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )] // L-shaped refinement
+     level_0 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+    // level_0 = [(N/4 + 5 , N/4 + 5),( N/4 + 10, N/4 + 10)] 
+    // level_0 = [(1,1), (30,30)] 
+   }
+}
+
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 1.0
+   timer_list = "IBTK::*::*"
+}

--- a/multigrid.cpp
+++ b/multigrid.cpp
@@ -321,11 +321,12 @@ main(int argc, char* argv[])
             new VCTwoFluidStaggeredStokesBoxRelaxationFACOperator(
                 "KrylovPrecondStrategy",
                 // app_initializer->getComponentDatabase("KrylovPrecondStrategy"),
-                "Krylov_precond_",
-                input_db->getDouble("w"),
-                C,
-                D);
+                "Krylov_precond_");
         fac_precondition_strategy->setThnIdx(thn_cc_idx);
+        fac_precondition_strategy->setCandDCoefficients(C, D);
+        fac_precondition_strategy->setUnderRelaxationParamater(input_db->getDouble("w"));
+        fac_precondition_strategy->setViscosityCoefficient(1.0, 1.0);
+        fac_precondition_strategy->setViscosityCoefficient(1.0, 1.0);
         Pointer<FullFACPreconditioner> Krylov_precond =
             new FullFACPreconditioner("KrylovPrecond",
                                       fac_precondition_strategy,

--- a/smooth.cpp
+++ b/smooth.cpp
@@ -272,9 +272,13 @@ main(int argc, char* argv[])
         p_fcn.setDataOnPatchHierarchy(p_cc_idx, p_cc_var, patch_hierarchy, 0.0);
 
         // Setup the box relaxation FAC operator
-        VCTwoFluidStaggeredStokesBoxRelaxationFACOperator box_relax("box_relax", "", 1.0 /*w*/, 0.0 /*C*/, 1.0 /*D*/);
+        VCTwoFluidStaggeredStokesBoxRelaxationFACOperator box_relax("box_relax", "");
         box_relax.setThnIdx(thn_cc_idx);
         box_relax.setToZero(u_vec, 0);
+        box_relax.setCandDCoefficients(0.0, 1.0);
+        box_relax.setUnderRelaxationParamater(1.0);
+        box_relax.setViscosityCoefficient(1.0, 1.0);
+        box_relax.setDragCoefficient(1.0, 1.0, 1.0);
 
         for (int i = 0; i <= 680; i++)
         {

--- a/time_stepping.cpp
+++ b/time_stepping.cpp
@@ -84,6 +84,9 @@ main(int argc, char* argv[])
                                         box_generator,
                                         load_balancer);
 
+        ins_integrator->setViscosityCoefficient(1.0, 1.0);
+        ins_integrator->setDragCoefficient(1.0, 1.0, 1.0);
+
         // Setup velocity and pressures functions.
         Pointer<CartGridFunction> un_init =
             new muParserCartGridFunction("un", app_initializer->getComponentDatabase("un"), grid_geometry);

--- a/time_stepping.cpp
+++ b/time_stepping.cpp
@@ -99,7 +99,7 @@ main(int argc, char* argv[])
         // Set up Thn functions
         Pointer<CartGridFunction> thn_fcn =
             new muParserCartGridFunction("thn", app_initializer->getComponentDatabase("thn"), grid_geometry);
-        ins_integrator->setNetworkVolumeFractionFunction(thn_fcn);
+        ins_integrator->setNetworkVolumeFractionFunction(thn_fcn, true);
 
         // Set up forcing function
         Pointer<CartGridFunction> fn_fcn =


### PR DESCRIPTION
Add the option of advecting theta. You can register an `AdvDiffHierarchyIntegrator` object that knows how to advect theta. Also adds in an initial four roll mill problem with the make target `four_roll_mill`.

This runs, but if theta is small or large, i.e. thn > 0.8 or thn < 0.2, we need to crank up the preconditioner sweeps considerable. I don't quite understand why yet. We should investigate the order of accuracy of the time integrator before the advection diffusion integrator is merged.