### PR TITLE
Quick fix for regridding.

### DIFF
--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -479,13 +479,13 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::resetHierarchyConfigurationSpecialize
 
     // Reset the hierarchy operations objects.
     d_hier_cc_data_ops->setPatchHierarchy(hierarchy);
-    d_hier_cc_data_ops->resetLevels(coarsest_level, finest_level);
+    d_hier_cc_data_ops->resetLevels(0, hierarchy->getFinestLevelNumber());
 
     d_hier_sc_data_ops->setPatchHierarchy(hierarchy);
-    d_hier_sc_data_ops->resetLevels(coarsest_level, finest_level);
+    d_hier_sc_data_ops->resetLevels(0, hierarchy->getFinestLevelNumber());
 
     d_hier_fc_data_ops->setPatchHierarchy(hierarchy);
-    d_hier_fc_data_ops->resetLevels(coarsest_level, finest_level);
+    d_hier_fc_data_ops->resetLevels(0, hierarchy->getFinestLevelNumber());
 }
 
 void
@@ -861,6 +861,11 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const d
     // Execute any registered callbacks.
     executePostprocessIntegrateHierarchyCallbackFcns(
         current_time, new_time, skip_synchronize_new_state_data, num_cycles);
+
+    d_stokes_op = nullptr;
+    d_stokes_solver = nullptr;
+    d_precond_op = nullptr;
+    d_stokes_precond = nullptr;
     return;
 } // postprocessIntegrateHierarchy
 
@@ -877,12 +882,6 @@ double
 INSVCTwoFluidStaggeredHierarchyIntegrator::getStableTimestep(Pointer<Patch<NDIM>> /*patch*/) const
 {
     return d_dt_init;
-}
-
-void
-INSVCTwoFluidStaggeredHierarchyIntegrator::synchronizeHierarchyDataSpecialized(VariableContextType ctx_type)
-{
-    // intentionally blank.
 }
 
 void

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.h
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.h
@@ -206,8 +206,6 @@ public:
 
     double getStableTimestep(SAMRAI::tbox::Pointer<SAMRAI::hier::Patch<NDIM>> patch) const override;
 
-    void synchronizeHierarchyDataSpecialized(IBTK::VariableContextType ctx_type) override;
-
     /*!
      * Reset cached hierarchy dependent data.
      */


### PR DESCRIPTION
This is a quick fix for a regridding issue that was present. I think we need to be careful about how and when solvers and operators (and temporary vectors) are destroyed. If they are destroyed _after_ a regridding operation, then I think any scratch data allocated by the operator will be lost.

This is a quick fix for the issue. We just destroy all the operators and solvers after a time step, and recreate them at the begging of a time step.