### PR TITLE
Four roll mill updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ TARGET_SOURCES(time_stepping PRIVATE VCTwoFluidStaggeredStokesOperator.cpp VCTwo
 TARGET_LINK_LIBRARIES(time_stepping IBAMR::IBAMR2d)
 
 ADD_EXECUTABLE(four_roll_mill four_roll_mill.cpp)
-TARGET_SOURCES(four_roll_mill PRIVATE VCTwoFluidStaggeredStokesOperator.cpp VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp FullFACPreconditioner.cpp RBGS.f INSVCTwoFluidStaggeredHierarchyIntegrator.cpp)
+TARGET_SOURCES(four_roll_mill PRIVATE VCTwoFluidStaggeredStokesOperator.cpp VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp FullFACPreconditioner.cpp RBGS.f INSVCTwoFluidStaggeredHierarchyIntegrator.cpp FRMThnForcing.cpp)
 TARGET_LINK_LIBRARIES(four_roll_mill IBAMR::IBAMR2d)
 
 ADD_SUBDIRECTORY(tests)

--- a/FRMThnForcing.cpp
+++ b/FRMThnForcing.cpp
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2014 - 2020 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#include "FRMThnForcing.h"
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+#include <SAMRAI_config.h>
+
+// SAMRAI INCLUDES
+#include <HierarchyDataOpsManager.h>
+
+double
+fx(const VectorNd& x, double t)
+{
+    return 2.0 * M_PI * std::sin(2.0 * M_PI * x[0]) * std::cos(2.0 * M_PI * x[1]) +
+           8.0 * M_PI * M_PI * std::sin(2.0 * M_PI * x[0]) * std::cos(2.0 * M_PI * x[1]);
+}
+
+double
+fy(const VectorNd& x, double t)
+{
+    return 2.0 * M_PI * std::cos(2.0 * M_PI * x[0]) * std::sin(2.0 * M_PI * x[1]) -
+           8.0 * M_PI * M_PI * std::cos(2.0 * M_PI * x[0]) * std::sin(2.0 * M_PI * x[1]);
+}
+
+double
+ths(const double thn)
+{
+    return 1.0 - thn;
+}
+
+/////////////////////////////// PUBLIC ///////////////////////////////////////
+
+FRMThnForcing::FRMThnForcing(Pointer<Variable<NDIM>> thn_var,
+                             Pointer<AdvDiffHierarchyIntegrator> adv_diff_hier_integrator,
+                             bool using_thn)
+    : d_thn_var(thn_var), d_adv_diff_hier_integrator(adv_diff_hier_integrator), d_using_thn(using_thn)
+{
+    // intentionally blank
+    return;
+} // FRMThnForcing
+
+FRMThnForcing::~FRMThnForcing()
+{
+    // intentionally blank
+    return;
+} // ~FRMThnForcing
+
+bool
+FRMThnForcing::isTimeDependent() const
+{
+    return true;
+} // isTimeDependent
+
+void
+FRMThnForcing::setDataOnPatchHierarchy(const int data_idx,
+                                       Pointer<Variable<NDIM>> var,
+                                       Pointer<PatchHierarchy<NDIM>> hierarchy,
+                                       const double data_time,
+                                       const bool initial_time,
+                                       const int coarsest_ln_in,
+                                       const int finest_ln_in)
+{
+    // Pull out thn index at the correct time.
+    auto var_db = VariableDatabase<NDIM>::getDatabase();
+    const int thn_cur_idx =
+        var_db->mapVariableAndContextToIndex(d_thn_var, d_adv_diff_hier_integrator->getCurrentContext());
+    const int thn_new_idx =
+        var_db->mapVariableAndContextToIndex(d_thn_var, d_adv_diff_hier_integrator->getNewContext());
+    const int thn_scr_idx =
+        var_db->mapVariableAndContextToIndex(d_thn_var, d_adv_diff_hier_integrator->getScratchContext());
+    bool scr_is_allocated = d_adv_diff_hier_integrator->isAllocatedPatchData(thn_scr_idx);
+    if (!scr_is_allocated) d_adv_diff_hier_integrator->allocatePatchData(thn_scr_idx, data_time);
+
+    HierarchyCellDataOpsReal<NDIM, double> hier_cc_data_ops(hierarchy);
+
+    if (d_adv_diff_hier_integrator->isAllocatedPatchData(thn_new_idx))
+    {
+        hier_cc_data_ops.linearSum(thn_scr_idx, 0.5, thn_cur_idx, 0.5, thn_new_idx);
+    }
+    else
+    {
+        hier_cc_data_ops.copyData(thn_scr_idx, thn_cur_idx);
+    }
+    // Fill ghost cells for thn_scratch.
+    using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
+    std::vector<ITC> ghost_cell_comp = { ITC(thn_scr_idx, "CONSERVATIVE_LINEAR_REFINE", false, "NONE") };
+    HierarchyGhostCellInterpolation hier_ghost_fill;
+    hier_ghost_fill.initializeOperatorState(ghost_cell_comp, hierarchy);
+    hier_ghost_fill.fillData(data_time);
+
+    // Compute a staggered-grid approximation to -gamma*T on each patch level.
+    const int coarsest_ln = (coarsest_ln_in == -1 ? 0 : coarsest_ln_in);
+    const int finest_ln = (finest_ln_in == -1 ? hierarchy->getFinestLevelNumber() : finest_ln_in);
+    for (int level_num = coarsest_ln; level_num <= finest_ln; ++level_num)
+    {
+        setDataOnPatchLevel(data_idx, var, hierarchy->getPatchLevel(level_num), data_time, initial_time);
+    }
+
+    return;
+} // setDataOnPatchHierarchy
+
+void
+FRMThnForcing::setDataOnPatch(const int data_idx,
+                              Pointer<Variable<NDIM>> /*var*/,
+                              Pointer<Patch<NDIM>> patch,
+                              const double data_time,
+                              const bool initial_time,
+                              Pointer<PatchLevel<NDIM>> /*patch_level*/)
+{
+    // Loop through all indices on patch and fill in force*thn.
+    Pointer<SideData<NDIM, double>> F_data = patch->getPatchData(data_idx);
+    F_data->fillAll(0.0);
+    if (initial_time) return;
+    Pointer<CellData<NDIM, double>> thn_scr_data =
+        patch->getPatchData(d_thn_var, d_adv_diff_hier_integrator->getScratchContext());
+    const Box<NDIM>& patch_box = patch->getBox();
+    Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
+    const double* const dx = pgeom->getDx();
+    const double* const xlow = pgeom->getXLower();
+    const hier::Index<NDIM>& idx_low = patch_box.lower();
+    const int axis = NDIM - 1;
+    for (int axis = 0; axis < NDIM; ++axis)
+    {
+        for (SideIterator<NDIM> si(patch_box, axis); si; si++)
+        {
+            const SideIndex<NDIM>& idx = si();
+            VectorNd x;
+            for (int d = 0; d < NDIM; ++d)
+                x[d] = xlow[d] + dx[d] * (static_cast<double>(idx(d) - idx_low(d)) + (axis == d ? 0.0 : 0.5));
+            double thn = 0.5 * ((*thn_scr_data)(idx.toCell(0)) + (*thn_scr_data)(idx.toCell(1)));
+            double th = d_using_thn ? thn : ths(thn);
+            (*F_data)(idx) = th * (axis == 0 ? fx(x, data_time) : fy(x, data_time));
+        }
+    }
+    return;
+} // setDataOnPatch
+
+//////////////////////////////////////////////////////////////////////////////

--- a/FRMThnForcing.h
+++ b/FRMThnForcing.h
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (c) 2014 - 2021 by the IBAMR developers
+// All rights reserved.
+//
+// This file is part of IBAMR.
+//
+// IBAMR is free software and is distributed under the 3-clause BSD
+// license. The full text of the license can be found in the file
+// COPYRIGHT at the top level directory of IBAMR.
+//
+// ---------------------------------------------------------------------
+
+#ifndef included_FRMThnForcing
+#define included_FRMThnForcing
+
+/////////////////////////////// INCLUDES /////////////////////////////////////
+
+// IBAMR INCLUDES
+#include <ibamr/AdvDiffHierarchyIntegrator.h>
+#include <ibamr/app_namespaces.h>
+
+/////////////////////////////// CLASS DEFINITION /////////////////////////////
+
+/*!
+ * \brief Class FRMThnForcing provides forcing for the momentum equations
+ * based on the Boussinesq approximation to the variable-density incompressible
+ * Navier-Stokes equations.
+ */
+class FRMThnForcing : public CartGridFunction
+{
+public:
+    /*!
+     * \brief Class constructor.
+     */
+    FRMThnForcing(Pointer<Variable<NDIM>> thn_var,
+                  Pointer<AdvDiffHierarchyIntegrator> adv_diff_hier_integrator,
+                  bool using_thn);
+
+    /*!
+     * \brief Empty destructor.
+     */
+    ~FRMThnForcing();
+
+    /*!
+     * \name Methods to set patch data.
+     */
+    //\{
+
+    /*!
+     * \brief Indicates whether the concrete FRMThnForcing object is
+     * time-dependent.
+     */
+    bool isTimeDependent() const;
+
+    /*!
+     * \brief Evaluate the function on the patch interiors on the specified
+     * levels of the patch hierarchy.
+     */
+    void setDataOnPatchHierarchy(const int data_idx,
+                                 Pointer<Variable<NDIM>> var,
+                                 Pointer<PatchHierarchy<NDIM>> hierarchy,
+                                 const double data_time,
+                                 const bool initial_time = false,
+                                 const int coarsest_ln = -1,
+                                 const int finest_ln = -1);
+
+    /*!
+     * \brief Evaluate the function on the patch interior.
+     */
+    void setDataOnPatch(const int data_idx,
+                        Pointer<Variable<NDIM>> var,
+                        Pointer<Patch<NDIM>> patch,
+                        const double data_time,
+                        const bool initial_time = false,
+                        Pointer<PatchLevel<NDIM>> patch_level = Pointer<PatchLevel<NDIM>>(NULL));
+
+    //\}
+
+private:
+    FRMThnForcing();
+
+    FRMThnForcing(const FRMThnForcing& from);
+
+    FRMThnForcing& operator=(const FRMThnForcing& that);
+
+    Pointer<Variable<NDIM>> d_thn_var;
+    Pointer<AdvDiffHierarchyIntegrator> d_adv_diff_hier_integrator;
+    bool d_using_thn = true;
+};
+
+//////////////////////////////////////////////////////////////////////////////
+
+#endif // #ifndef included_FRMThnForcing

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -420,7 +420,37 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::initializeLevelDataSpecialized(Pointe
     // Do any kind of Hierarchy specific initialization on a given patch level.
     // Note: All initialization and regridding of state variables is managed by HierarchyIntegrator.
     // Example uses of this include mantaining a vorticity value to see where things should be refined or checking norms
-    // of quantities before and after regridding. intentionally blank.
+    // of quantities before and after regridding.
+    Pointer<PatchLevel<NDIM>> new_level = hierarchy->getPatchLevel(level_number);
+
+    // Compute gradient of theta for initial tagging
+    if (initial_time)
+    {
+        HierarchyDataOpsManager<NDIM>* hier_ops_manager = HierarchyDataOpsManager<NDIM>::getManager();
+        Pointer<HierarchyCellDataOpsReal<NDIM, double>> hier_cc_data_ops =
+            hier_ops_manager->getOperationsDouble(d_grad_thn_var, d_hierarchy, true);
+
+        auto var_db = VariableDatabase<NDIM>::getDatabase();
+        const int grad_thn_idx = var_db->mapVariableAndContextToIndex(d_grad_thn_var, getCurrentContext());
+        const int thn_idx = var_db->mapVariableAndContextToIndex(d_thn_cc_var, getCurrentContext());
+
+        // Fill in with initial conditions.
+        d_thn_init_fcn->setDataOnPatchLevel(thn_idx, d_thn_cc_var, new_level, init_data_time, initial_time);
+
+        // Now fill in ghost cells
+        using ITC = HierarchyGhostCellInterpolation::InterpolationTransactionComponent;
+        std::vector<ITC> ghost_cell_comp(1);
+        ghost_cell_comp[0] = ITC(thn_idx, "CONSERVATIVE_LINEAR_REFINE", false, "NONE", "LINEAR", false, nullptr);
+
+        Pointer<HierarchyGhostCellInterpolation> ghost_cell_fill = new HierarchyGhostCellInterpolation();
+        // Note: when we create a new level, the coarser levels should already be created. So we can use that data to
+        // fill ghost cells.
+        ghost_cell_fill->initializeOperatorState(ghost_cell_comp, hierarchy, 0, level_number);
+        HierarchyMathOps hier_math_ops("HierMathOps", hierarchy, 0, level_number);
+        hier_math_ops.grad(grad_thn_idx, d_grad_thn_var, 1.0, thn_idx, d_thn_cc_var, ghost_cell_fill, init_data_time);
+        // TODO: Replace this with a max over the L2 norm.
+        d_max_grad_thn = hier_cc_data_ops->maxNorm(grad_thn_idx, IBTK::invalid_index);
+    }
 }
 
 void
@@ -450,7 +480,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(
             Pointer<Patch<NDIM>> patch = level->getPatch(p());
             Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
             Pointer<CellData<NDIM, double>> grad_thn_data = patch->getPatchData(d_grad_thn_var, getCurrentContext());
-            Pointer<CellData<NDIM, int> > tagged_data = patch->getPatchData(tag_idx);
+            Pointer<CellData<NDIM, int>> tagged_data = patch->getPatchData(tag_idx);
 
             for (CellIterator<NDIM> ci(patch->getBox()); ci; ci++) // cell-centers
             {
@@ -463,6 +493,7 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(
                 if (grad_thn_norm > grad_abs_thresh || (grad_thn_norm / d_max_grad_thn) > grad_rel_thresh)
                     (*tagged_data)(idx) = 1;
             }
+            tagged_data->print(tagged_data->getBox());
         }
     }
     return;

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.h
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.h
@@ -108,6 +108,11 @@ public:
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> getPressureVariable() const;
 
+    inline SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> getNetworkVolumeFractionVariable() const
+    {
+        return d_thn_cc_var;
+    }
+
     /*!
      * \brief Set the viscosity coefficients for the viscous stresses.
      */

--- a/RBGS.f
+++ b/RBGS.f
@@ -79,7 +79,7 @@ c
       double precision thn_lower_x, thn_lower_y
       double precision thn_upper_x, thn_upper_y
       double precision thn_imhalf_jphalf, thn_imhalf_jmhalf
-      double precisionthn_iphalf_jphalf, thn_iphalf_jmhalf
+      double precision thn_iphalf_jphalf, thn_iphalf_jmhalf
 c    
       double precision A_box(9,9)
       double precision b(9)

--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
@@ -73,38 +73,38 @@
 
 extern "C"
 {
-    void R_B_G_S(const double*,  // dx
-                 const int&,     // ilower0
-                 const int&,     // iupper0
-                 const int&,     // ilower1
-                 const int&,     // iupper1
-                 double* const,  // un_data_0
-                 double* const,  // un_data_1
-                 const int&,     // un_gcw
-                 double* const,  // us_data_0
-                 double* const,  // us_data_0
-                 const int&,     // us_gcw
-                 double* const,  // p_data_
-                 const int&,     // p_gcw
-                 double* const,  // f_p_data
-                 const int&,     // f_p_gcw
-                 double* const,  // f_un_data_0
-                 double* const,  // f_un_data_1
-                 const int&,     // f_un_gcw
-                 double* const,  // f_us_data_0
-                 double* const,  // f_us_data_1
-                 const int&,     // f_us_gcw
-                 double* const,  // thn_data
-                 const int&,     // thn_gcw
-                 const double&,  // eta_n    // whatever will be passed in will be treated as a reference to a double
-                 const double&,  // eta_s    // telling the compiler that the function is expecting a reference
-                 const double&,  // nu_n
-                 const double&,  // nu_s
-                 const double&,  // xi
-                 const double&,  // w = under relaxation factor
-                 const double&,  // C in C*u term
+    void R_B_G_S(const double*, // dx
+                 const int&,    // ilower0
+                 const int&,    // iupper0
+                 const int&,    // ilower1
+                 const int&,    // iupper1
+                 double* const, // un_data_0
+                 double* const, // un_data_1
+                 const int&,    // un_gcw
+                 double* const, // us_data_0
+                 double* const, // us_data_0
+                 const int&,    // us_gcw
+                 double* const, // p_data_
+                 const int&,    // p_gcw
+                 double* const, // f_p_data
+                 const int&,    // f_p_gcw
+                 double* const, // f_un_data_0
+                 double* const, // f_un_data_1
+                 const int&,    // f_un_gcw
+                 double* const, // f_us_data_0
+                 double* const, // f_us_data_1
+                 const int&,    // f_us_gcw
+                 double* const, // thn_data
+                 const int&,    // thn_gcw
+                 const double&, // eta_n    // whatever will be passed in will be treated as a reference to a double
+                 const double&, // eta_s    // telling the compiler that the function is expecting a reference
+                 const double&, // nu_n
+                 const double&, // nu_s
+                 const double&, // xi
+                 const double&, // w = under relaxation factor
+                 const double&, // C in C*u term
                  const double&, // D
-                 const int&); // red_or_black
+                 const int&);   // red_or_black
 }
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 namespace IBTK
@@ -330,9 +330,9 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(
     IBTK_TIMER_START(t_smooth_error);
 
     // Get the vector components. These pull out patch data indices
-    const int un_idx = error.getComponentDescriptorIndex(0); // network velocity, Un
-    const int us_idx = error.getComponentDescriptorIndex(1); // solvent velocity, Us
-    const int P_idx = error.getComponentDescriptorIndex(2);  // pressure
+    const int un_idx = error.getComponentDescriptorIndex(0);      // network velocity, Un
+    const int us_idx = error.getComponentDescriptorIndex(1);      // solvent velocity, Us
+    const int P_idx = error.getComponentDescriptorIndex(2);       // pressure
     const int thn_idx = d_thn_idx;
     const int f_un_idx = residual.getComponentDescriptorIndex(0); // RHS_Un
     const int f_us_idx = residual.getComponentDescriptorIndex(1); // RHS_Us
@@ -342,7 +342,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(
     Pointer<PatchLevel<NDIM>> level = d_hierarchy->getPatchLevel(level_num);
 
     // outer for loop for number of sweeps
-    for (int sweep = 0; sweep < 2*num_sweeps; sweep++)
+    for (int sweep = 0; sweep < 2 * num_sweeps; sweep++)
     {
         // Fill in ghost cells. We only want to use values on our current level to fill in ghost cells.
         // TODO: d_ghostfill_no_restrict_scheds does not fill in ghost cells in at coarse fine interfaces. We need to
@@ -413,10 +413,10 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::smoothError(
             const IntVector<NDIM>& f_p_gcw = f_p_data->getGhostCellWidth();
             int red_or_black = sweep % 2; // red = 0 and black = 1
             R_B_G_S(dx,
-                    patch_lower(0), // ilower0
-                    patch_upper(0), // iupper0
-                    patch_lower(1), // ilower1
-                    patch_upper(1), // iupper1
+                    patch_lower(0),       // ilower0
+                    patch_upper(0),       // iupper0
+                    patch_lower(1),       // ilower1
+                    patch_upper(1),       // iupper1
                     un_data_0,
                     un_data_1,
                     un_gcw.min(),
@@ -533,7 +533,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
             Pointer<CartesianPatchGeometry<NDIM>> pgeom = patch->getPatchGeometry();
             const double* const dx = pgeom->getDx(); // dx[0] -> x, dx[1] -> y
             const double* const xlow =
-                pgeom->getXLower(); // {xlow[0], xlow[1]} -> physical location of bottom left of box.
+                pgeom->getXLower();                  // {xlow[0], xlow[1]} -> physical location of bottom left of box.
             const hier::Index<NDIM>& idx_low = patch->getBox().lower();
             Pointer<CellData<NDIM, double>> p_data = patch->getPatchData(P_idx);
             Pointer<CellData<NDIM, double>> rhs_P_data =
@@ -553,9 +553,6 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
             for (CellIterator<NDIM> ci(patch->getBox()); ci; ci++) // cell-centers
             {
                 const CellIndex<NDIM>& idx = ci();
-                VectorNd x; // <- Eigen3 vector
-                for (int d = 0; d < NDIM; ++d)
-                    x[d] = xlow[d] + dx[d] * (idx(d) - idx_low(d) + 0.5); // Get's physical location of idx.
 
                 SideIndex<NDIM> lower_x_idx(idx, 0, 0); // (i-1/2,j)
                 SideIndex<NDIM> upper_x_idx(idx, 0, 1); // (i+1/2,j)
@@ -588,19 +585,17 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
 
             for (SideIterator<NDIM> si(patch->getBox(), 0); si; si++) // side-centers in x-dir
             {
-                const SideIndex<NDIM>& idx = si(); // axis = 0, (i-1/2,j)
-                // pout << "\n At idx " << idx << " \n ";
+                const SideIndex<NDIM>& idx = si();                    // axis = 0, (i-1/2,j)
 
-                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i-1,j)
-                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)
-                SideIndex<NDIM> lower_y_idx(idx_c_up, 1, 0); // (i,j-1/2)
-                SideIndex<NDIM> upper_y_idx(idx_c_up, 1, 1); // (i,j+1/2)
-                SideIndex<NDIM> l_y_idx(idx_c_low, 1, 0);    // (i-1,j-1/2)
-                SideIndex<NDIM> u_y_idx(idx_c_low, 1, 1);    // (i-1,j+1/2)
+                CellIndex<NDIM> idx_c_low = idx.toCell(0);            // (i-1,j)
+                CellIndex<NDIM> idx_c_up = idx.toCell(1);             // (i,j)
+                SideIndex<NDIM> lower_y_idx(idx_c_up, 1, 0);          // (i,j-1/2)
+                SideIndex<NDIM> upper_y_idx(idx_c_up, 1, 1);          // (i,j+1/2)
+                SideIndex<NDIM> l_y_idx(idx_c_low, 1, 0);             // (i-1,j-1/2)
+                SideIndex<NDIM> u_y_idx(idx_c_low, 1, 1);             // (i-1,j+1/2)
 
                 // thn at sides
                 double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up)); // thn(i-1/2,j)
-                // pout << "thn_lower is " << thn_lower << "\n";
                 // thn at corners
                 double thn_imhalf_jphalf =
                     0.25 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up) + (*thn_data)(idx_c_up + yp) +
@@ -657,18 +652,16 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
                      d_C * convertToThs(thn_lower) * (*us_data)(idx));
             }
 
-            // pout << "\n\n Looping over y-dir side-centers \n\n";
-
             for (SideIterator<NDIM> si(patch->getBox(), 1); si; si++) // side-centers in y-dir
             {
-                const SideIndex<NDIM>& idx = si(); // axis = 1, (i,j-1/2)
+                const SideIndex<NDIM>& idx = si();                    // axis = 1, (i,j-1/2)
 
-                CellIndex<NDIM> idx_c_low = idx.toCell(0);   // (i,j-1)
-                CellIndex<NDIM> idx_c_up = idx.toCell(1);    // (i,j)
-                SideIndex<NDIM> lower_x_idx(idx_c_up, 0, 0); // (i-1/2,j)
-                SideIndex<NDIM> upper_x_idx(idx_c_up, 0, 1); // (i+1/2,j)
-                SideIndex<NDIM> l_x_idx(idx_c_low, 0, 0);    // (i-1/2,j-1)
-                SideIndex<NDIM> u_x_idx(idx_c_low, 0, 1);    // (i+1/2,j-1)
+                CellIndex<NDIM> idx_c_low = idx.toCell(0);            // (i,j-1)
+                CellIndex<NDIM> idx_c_up = idx.toCell(1);             // (i,j)
+                SideIndex<NDIM> lower_x_idx(idx_c_up, 0, 0);          // (i-1/2,j)
+                SideIndex<NDIM> upper_x_idx(idx_c_up, 0, 1);          // (i+1/2,j)
+                SideIndex<NDIM> l_x_idx(idx_c_low, 0, 0);             // (i-1/2,j-1)
+                SideIndex<NDIM> u_x_idx(idx_c_low, 0, 1);             // (i+1/2,j-1)
 
                 // thn at sides
                 double thn_lower = 0.5 * ((*thn_data)(idx_c_low) + (*thn_data)(idx_c_up)); // thn(i,j-1/2)

--- a/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
+++ b/VCTwoFluidStaggeredStokesBoxRelaxationFACOperator.cpp
@@ -629,7 +629,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
                 (*res_un_data)(idx) =
                     (*rhs_un_data)(idx) -
                     (d_D * (ddx_Thn_dx_un + ddy_Thn_dy_un + ddy_Thn_dx_vn + ddx_Thn_dy_vn + drag_n + pressure_n) +
-                     d_C * (*un_data)(idx));
+                     d_C * thn_lower * (*un_data)(idx));
 
                 // solvent equation
                 double ddx_Ths_dx_us =
@@ -654,7 +654,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
                 (*res_us_data)(idx) =
                     (*rhs_us_data)(idx) -
                     (d_D * (ddx_Ths_dx_us + ddy_Ths_dy_us + ddy_Ths_dx_vs + ddx_Ths_dy_vs + drag_s + pressure_s) +
-                     d_C * (*us_data)(idx));
+                     d_C * convertToThs(thn_lower) * (*us_data)(idx));
             }
 
             // pout << "\n\n Looping over y-dir side-centers \n\n";
@@ -701,7 +701,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
                 (*res_un_data)(idx) =
                     (*rhs_un_data)(idx) -
                     (d_D * (ddy_Thn_dy_un + ddx_Thn_dx_un + ddx_Thn_dy_vn + ddy_Thn_dx_vn + drag_n + pressure_n) +
-                     d_C * (*un_data)(idx));
+                     d_C * thn_lower * (*un_data)(idx));
 
                 // Solvent equation
                 double ddy_Ths_dy_us =
@@ -726,7 +726,7 @@ VCTwoFluidStaggeredStokesBoxRelaxationFACOperator::computeResidual(SAMRAIVectorR
                 (*res_us_data)(idx) =
                     (*rhs_us_data)(idx) -
                     (d_D * (ddy_Ths_dy_us + ddx_Ths_dx_us + ddx_Ths_dy_vs + ddy_Ths_dx_vs + drag_s + pressure_s) +
-                     d_C * (*us_data)(idx));
+                     d_C * convertToThs(thn_lower) * (*us_data)(idx));
             }
         }
     }

--- a/four_roll_mill.cpp
+++ b/four_roll_mill.cpp
@@ -35,6 +35,7 @@
 #include <StandardTagAndInitialize.h>
 
 // Local includes
+#include "FRMThnForcing.h"
 #include "INSVCTwoFluidStaggeredHierarchyIntegrator.h"
 
 /*******************************************************************************
@@ -90,8 +91,13 @@ main(int argc, char* argv[])
                                         box_generator,
                                         load_balancer);
 
-        ins_integrator->setViscosityCoefficient(0.04, 0.04);
-        ins_integrator->setDragCoefficient(250.0 * 0.04, 1.0, 1.0);
+        const double eta_n = input_db->getDouble("ETA_N");
+        const double eta_s = input_db->getDouble("ETA_S");
+        const double xi = input_db->getDouble("XI");
+        const double nu_n = input_db->getDouble("NU_N");
+        const double nu_s = input_db->getDouble("NU_S");
+        ins_integrator->setViscosityCoefficient(eta_n, eta_s);
+        ins_integrator->setDragCoefficient(xi, nu_n, nu_s);
 
         // Setup velocity and pressures functions.
         Pointer<CartGridFunction> un_init =
@@ -110,9 +116,9 @@ main(int argc, char* argv[])
 
         // Set up forcing function
         Pointer<CartGridFunction> fn_fcn =
-            new muParserCartGridFunction("f_un", app_initializer->getComponentDatabase("f_un"), grid_geometry);
+            new FRMThnForcing(ins_integrator->getNetworkVolumeFractionVariable(), adv_diff_integrator, true);
         Pointer<CartGridFunction> fs_fcn =
-            new muParserCartGridFunction("f_us", app_initializer->getComponentDatabase("f_us"), grid_geometry);
+            new FRMThnForcing(ins_integrator->getNetworkVolumeFractionVariable(), adv_diff_integrator, false);
         ins_integrator->setForcingFunctions(fn_fcn, fs_fcn, nullptr);
 
         // Set up visualizations

--- a/input2d.four_roll_mill
+++ b/input2d.four_roll_mill
@@ -1,20 +1,27 @@
 RHO = 1.0
-MAX_MULTIGRID_LEVELS = 5
+MAX_MULTIGRID_LEVELS = 4
 START_TIME = 0.0
 END_TIME = 1.0
 NUM_CYCLES = 1
-DT_MAX = 0.005
+DT_MAX = 0.0001
 ENABLE_LOGGING = TRUE
 W = 0.75
 USE_PRECONDITIONER = TRUE
-N = 64
-VIZ_DUMP_TIME_INTERVAL = 0.01
+N = 16
+VIZ_DUMP_TIME_INTERVAL = 0.005
 DELTA = 0.175
+TAG_BUFFER = 1
 
 ADV_DIFF_NUM_CYCLES = 1
 ADV_DIFF_CONVECTIVE_OP_TYPE = "CUI"
 ADV_DIFF_CONVECTIVE_TS_TYPE = "FORWARD_EULER"
 ADV_DIFF_CONVECTIVE_FORM = "CONSERVATIVE"
+
+ETA_S = 0.04
+ETA_N = 4.0
+NU_N = 1.0
+NU_S = 1.0
+XI = 250.0*ETA_S
 
 un {
    function_0 = "0.0"
@@ -28,21 +35,11 @@ us {
 
 p {
    function = "0.0"
-} // pressure has mean 0
-
-f_un {
-   function_0 = "0.0"
-   function_1 = "0.0"
-}
-
-f_us {
-   function_0 = "(2.0*PI*sin(2.0*PI*X_0)*cos(2.0*PI*X_1) + 8*PI*PI*sin(2*PI*X_0)*cos(2*PI*X_1))"
-   function_1 = "(2.0*PI*cos(2.0*PI*X_0)*sin(2.0*PI*X_1) - 8*PI*PI*sin(2*PI*X_1)*cos(2*PI*X_0))"
 }
 
 thn {
    delta = DELTA
-   function = "0.05 + ((sqrt(X_0*X_0+X_1*X_1)<delta) ? (1989.0/(896*PI)*(1.0-((X_0*X_0+X_1*X_1)/(delta*delta))^4.0)^4.0*(4.0*((X_0*X_0+X_1*X_1)/(delta*delta))^4.0+1.0)) : 0.0)"
+   function = "0.25 + 0.25*((sqrt(X_0*X_0+X_1*X_1)<delta) ? (1989.0/(896*PI)*(1.0-((X_0*X_0+X_1*X_1)/(delta*delta))^4.0)^4.0*(4.0*((X_0*X_0+X_1*X_1)/(delta*delta))^4.0+1.0)) : 0.0)"
    //function = "0.5"
    //function = "0.25*sin(2*PI*X_0)*sin(2*PI*X_1) + 0.5"
 }
@@ -56,15 +53,18 @@ INSVCTwoFluidStaggeredHierarchyIntegrator {
    enable_logging                = ENABLE_LOGGING
    w = W
    use_preconditioner = USE_PRECONDITIONER
+   grad_abs_thresh = 0.75
+   use_grad_tagging = TRUE
+   tag_buffer = TAG_BUFFER
 
    solver_db {
       ksp_type = "fgmres"
    }
 
    precond_db {
-      cycle_type = "F_CYCLE"
-      num_pre_sweeps = 18
-      num_post_sweeps = 18
+      cycle_type = "V_CYCLE"
+      num_pre_sweeps = 15
+      num_post_sweeps = 15
       enable_logging = TRUE
       max_multigrid_levels = MAX_MULTIGRID_LEVELS
    }
@@ -104,10 +104,12 @@ CartesianGeometry {
 }
 
 GriddingAlgorithm {
-   max_levels = 1                 // Maximum number of levels in hierarchy.
+   max_levels = 4                 // Maximum number of levels in hierarchy.
 
    ratio_to_coarser {
-      level_1 = 2, 2              // vector ratio to next coarser level
+      level_1 = 4, 4              // vector ratio to next coarser level
+      level_2 = 2, 2
+      level_3 = 2, 2
    }
 
    largest_patch_size {
@@ -126,14 +128,7 @@ GriddingAlgorithm {
 }
 
 StandardTagAndInitialize {
-   tagging_method = "REFINE_BOXES"
-   RefineBoxes {
-    // level_0 = [( N/4 , N/4 ),( 3*N/4 - 1 , N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1, 3*N/4 - 2)]
-    // level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )] // L-shaped refinement
-     level_0 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
-    // level_0 = [(N/4 + 5 , N/4 + 5),( N/4 + 10, N/4 + 10)] 
-    // level_0 = [(1,1), (30,30)] 
-   }
+   tagging_method = "GRADIENT_DETECTOR"
 }
 
 LoadBalancer {


### PR DESCRIPTION
Fixes initial tagging of indices using the provided initial condition for volume fraction.

Fixes a couple of bugs in the preconditioner.

Updates four roll mill to use AMR. In particular, this sets things up to use 4 different levels of refinement. There are probably adjustments you can make to the preconditioner and time step size to make this run faster. I have not explored that.