### PR TITLE
Second order accuracy for time stepping

### DIFF
--- a/FullFACPreconditioner.cpp
+++ b/FullFACPreconditioner.cpp
@@ -282,6 +282,22 @@ FullFACPreconditioner::generateDenseHierarchy(Pointer<PatchHierarchy<NDIM>> base
         Pointer<PatchLevel<NDIM>> dense_level = d_dense_hierarchy->getPatchLevel(ln);
     }
 
+    if (d_enable_logging)
+    {
+        plog << "Printing dense hierarchy info\n";
+        for (int ln = 0; ln <= d_dense_hierarchy->getFinestLevelNumber(); ++ln)
+        {
+            plog << "On level " << ln << " of " << d_dense_hierarchy->getFinestLevelNumber() << "\n";
+            Pointer<PatchLevel<NDIM>> level = d_dense_hierarchy->getPatchLevel(ln);
+            const BoxArray<NDIM>& boxes = level->getBoxes();
+            for (int box_num = 0; box_num < boxes.size(); ++box_num)
+            {
+                const Box<NDIM>& box = boxes[box_num];
+                plog << box << "\n";
+            }
+        }
+    }
+
     Pointer<CartesianGridGeometry<NDIM>> cart_dense_geom = dense_geom;
     cart_dense_geom->addSpatialCoarsenOperator(new CartCellDoubleCubicCoarsen());
     cart_dense_geom->addSpatialCoarsenOperator(new CartSideDoubleCubicCoarsen());

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -493,7 +493,6 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::applyGradientDetectorSpecialized(
                 if (grad_thn_norm > grad_abs_thresh || (grad_thn_norm / d_max_grad_thn) > grad_rel_thresh)
                     (*tagged_data)(idx) = 1;
             }
-            tagged_data->print(tagged_data->getBox());
         }
     }
     return;

--- a/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
+++ b/INSVCTwoFluidStaggeredHierarchyIntegrator.cpp
@@ -619,10 +619,12 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     d_rhs_vec->setToScalar(0.0);
     if (d_f_un_fcn) d_f_un_fcn->setDataOnPatchHierarchy(f_un_idx, d_f_un_sc_var, d_hierarchy, half_time);
     if (d_f_us_fcn) d_f_us_fcn->setDataOnPatchHierarchy(f_us_idx, d_f_us_sc_var, d_hierarchy, half_time);
-    if (d_f_p_fcn) d_f_p_fcn->setDataOnPatchHierarchy(f_p_idx, d_f_cc_var, d_hierarchy, half_time);
+    // Divergence is not time-stepped. We need to prescribe the correct divergence at the time point for which we are
+    // solving.
+    if (d_f_p_fcn) d_f_p_fcn->setDataOnPatchHierarchy(f_p_idx, d_f_cc_var, d_hierarchy, new_time);
 
     // set-up RHS to treat viscosity and drag with backward Euler or Implicit Trapezoidal Rule:
-    // RHS = f(n) + C*theta_i(n)*u_i(n) + D1*(pressure + viscous + drag) for  i = n, s
+    // RHS = f(n) + C*theta_i(n)*u_i(n) + D1*(viscous + drag) for  i = n, s
     double D1 = std::numeric_limits<double>::signaling_NaN();
     double D2 = std::numeric_limits<double>::signaling_NaN();
     const double C = d_rho / dt;
@@ -645,7 +647,9 @@ INSVCTwoFluidStaggeredHierarchyIntegrator::preprocessIntegrateHierarchy(const do
     }
 
     VCTwoFluidStaggeredStokesOperator RHS_op("RHS_op", true);
-    RHS_op.setCandDCoefficients(C, D1);
+    // Divergence free condition and pressure are not time stepped. We do not need to account for the contributions in
+    // the RHS.
+    RHS_op.setCandDCoefficients(C, D1, 0.0, 0.0);
     RHS_op.setDragCoefficient(d_xi, d_nu_n, d_nu_s);
     RHS_op.setViscosityCoefficient(d_eta_n, d_eta_s);
     RHS_op.setThnIdx(thn_cur_idx); // Values at time t_n

--- a/VCTwoFluidStaggeredStokesOperator.cpp
+++ b/VCTwoFluidStaggeredStokesOperator.cpp
@@ -135,7 +135,11 @@ VCTwoFluidStaggeredStokesOperator::VCTwoFluidStaggeredStokesOperator(const std::
     if (input_db)
     {
         if (input_db->keyExists("c")) d_C = input_db->getDouble("c");
-        if (input_db->keyExists("d")) d_D = input_db->getDouble("d");
+        if (input_db->keyExists("d"))
+        {
+            d_D_u = input_db->getDouble("d");
+            d_D_p = d_D_u;
+        }
         if (input_db->keyExists("xi")) d_xi = input_db->getDouble("xi");
         if (input_db->keyExists("eta_n")) d_eta_n = input_db->getDouble("eta_n");
         if (input_db->keyExists("eta_s")) d_eta_s = input_db->getDouble("eta_s");
@@ -171,19 +175,21 @@ VCTwoFluidStaggeredStokesOperator::~VCTwoFluidStaggeredStokesOperator()
 void
 VCTwoFluidStaggeredStokesOperator::setVelocityPoissonSpecifications(const PoissonSpecifications& coefs)
 {
-    // Make sure things are constant
-#if !defined(NDEBUG)
-    TBOX_ASSERT(coefs.cIsConstant() && coefs.dIsConstant());
-#endif
-    setCandDCoefficients(coefs.getCConstant(), coefs.getDConstant());
+    TBOX_WARNING(d_object_name +
+                 "::setVelocityPoissonSpecifications: This function is not used. Use setCandDCoefficients instead.");
     return;
 } // setVelocityPoissonSpecifications
 
 void
-VCTwoFluidStaggeredStokesOperator::setCandDCoefficients(const double C, const double D)
+VCTwoFluidStaggeredStokesOperator::setCandDCoefficients(const double C,
+                                                        const double D_u,
+                                                        const double D_p,
+                                                        const double D_div)
 {
     d_C = C;
-    d_D = D;
+    d_D_u = D_u;
+    d_D_p = D_p;
+    d_D_div = D_div;
 }
 
 void
@@ -368,7 +374,7 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                                             (convertToThs(thn_lower_y) * (*us_data)(lower_y_idx))) /
                                            dx[1];
                 double div_us_ths = div_us_dot_ths_dx + div_us_dot_ths_dy;
-                (*A_P_data)(idx) = div_un_thn + div_us_ths;
+                (*A_P_data)(idx) = d_D_div * (div_un_thn + div_us_ths);
             }
 
             for (SideIterator<NDIM> si(patch->getBox(), 0); si; si++) // side-centers in x-dir
@@ -409,9 +415,8 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double drag_n =
                     -d_xi / d_nu_n * thn_lower * convertToThs(thn_lower) * ((*un_data)(idx) - (*us_data)(idx));
                 double pressure_n = -thn_lower / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*A_un_data)(idx) =
-                    d_D * (ddx_Thn_dx_un + ddy_Thn_dy_un + ddy_Thn_dx_vn + ddx_Thn_dy_vn + drag_n + pressure_n) +
-                    d_C * thn_lower * (*un_data)(idx);
+                (*A_un_data)(idx) = d_D_u * (ddx_Thn_dx_un + ddy_Thn_dy_un + ddy_Thn_dx_vn + ddx_Thn_dy_vn + drag_n) +
+                                    d_D_p * (pressure_n) + d_C * thn_lower * (*un_data)(idx);
 
                 // solvent equation
                 double ddx_Ths_dx_us =
@@ -432,9 +437,8 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double drag_s =
                     -d_xi / d_nu_s * thn_lower * convertToThs(thn_lower) * ((*us_data)(idx) - (*un_data)(idx));
                 double pressure_s = -convertToThs(thn_lower) / dx[0] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*A_us_data)(idx) =
-                    d_D * (ddx_Ths_dx_us + ddy_Ths_dy_us + ddy_Ths_dx_vs + ddx_Ths_dy_vs + drag_s + pressure_s) +
-                    d_C * convertToThs(thn_lower) * (*us_data)(idx);
+                (*A_us_data)(idx) = d_D_u * (ddx_Ths_dx_us + ddy_Ths_dy_us + ddy_Ths_dx_vs + ddx_Ths_dy_vs + drag_s) +
+                                    d_D_p * (pressure_s) + d_C * convertToThs(thn_lower) * (*us_data)(idx);
             }
 
             for (SideIterator<NDIM> si(patch->getBox(), 1); si; si++) // side-centers in y-dir
@@ -476,9 +480,8 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double drag_n =
                     -d_xi / d_nu_n * thn_lower * convertToThs(thn_lower) * ((*un_data)(idx) - (*us_data)(idx));
                 double pressure_n = -thn_lower / dx[1] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*A_un_data)(idx) =
-                    d_D * (ddy_Thn_dy_un + ddx_Thn_dx_un + ddx_Thn_dy_vn + ddy_Thn_dx_vn + drag_n + pressure_n) +
-                    d_C * thn_lower * (*un_data)(idx);
+                (*A_un_data)(idx) = d_D_u * (ddy_Thn_dy_un + ddx_Thn_dx_un + ddx_Thn_dy_vn + ddy_Thn_dx_vn + drag_n) +
+                                    d_D_p * (pressure_n) + d_C * thn_lower * (*un_data)(idx);
 
                 // Solvent equation
                 double ddy_Ths_dy_us =
@@ -499,9 +502,8 @@ VCTwoFluidStaggeredStokesOperator::apply(SAMRAIVectorReal<NDIM, double>& x, SAMR
                 double drag_s =
                     -d_xi / d_nu_s * thn_lower * convertToThs(thn_lower) * ((*us_data)(idx) - (*un_data)(idx));
                 double pressure_s = -convertToThs(thn_lower) / dx[1] * ((*p_data)(idx_c_up) - (*p_data)(idx_c_low));
-                (*A_us_data)(idx) =
-                    d_D * (ddy_Ths_dy_us + ddx_Ths_dx_us + ddx_Ths_dy_vs + ddy_Ths_dx_vs + drag_s + pressure_s) +
-                    d_C * convertToThs(thn_lower) * (*us_data)(idx);
+                (*A_us_data)(idx) = d_D_u * (ddy_Ths_dy_us + ddx_Ths_dx_us + ddx_Ths_dy_vs + ddy_Ths_dx_vs + drag_s) +
+                                    d_D_p * (pressure_s) + d_C * convertToThs(thn_lower) * (*us_data)(idx);
             }
         }
     }

--- a/input2d.timestepping.all_t
+++ b/input2d.timestepping.all_t
@@ -17,13 +17,13 @@ VISCOUS_TIME_STEPPING_TYPE = "TRAPEZOIDAL_RULE"
 
 // Inital conditions
 un {
-   function_0 = "cos(2*PI*X_0)"
-   function_1 = "cos(2*PI*X_1)"
+   function_0 = "cos(2*PI*X_0) + sin(2*PI*t)"
+   function_1 = "cos(2*PI*X_1) + sin(2*PI*t)"
 }
 
 us {
-   function_0 = "-cos(2*PI*X_0)"
-   function_1 = "-cos(2*PI*X_1)" 
+   function_0 = "-cos(2*PI*X_0) - sin(2*PI*t)"
+   function_1 = "-cos(2*PI*X_1) - sin(2*PI*t)"
 } 
 
 p {
@@ -47,20 +47,6 @@ f_p {
 thn {
    function = "0.5"
 }
-
-un_exact {
-   function_0 = "cos(2*PI*X_0) + sin(2*PI*t)"
-   function_1 = "cos(2*PI*X_1) + sin(2*PI*t)"
-}
-
-us_exact {
-   function_0 = "-cos(2*PI*X_0) - sin(2*PI*t)"
-   function_1 = "-cos(2*PI*X_1) - sin(2*PI*t)"
-} 
-
-p_exact {
-   function = "sin(2*PI*X_0)"
-} // pressure has mean 0
 
 INSVCTwoFluidStaggeredHierarchyIntegrator {
    rho                           = RHO


### PR DESCRIPTION
This fixes time evaluations of certain fields needed for second order accuracy. @bindi-nagda, I've forced pushed to this branch. When you have a chance, can you pull the branch and check that this still gives second order accuracy with your test problems? You made need to do a `git reset --hard origin/fix_rhs_timestepping` because of the force push.