### PR TITLE
Remove static initialization of timers.

### DIFF
--- a/multigrid/multigrid.cpp
+++ b/multigrid/multigrid.cpp
@@ -60,10 +60,6 @@ main(int argc, char* argv[])
         // file, and enable file logging.
         Pointer<AppInitializer> app_initializer = new AppInitializer(argc, argv, "stokes.log");
         Pointer<Database> input_db = app_initializer->getInputDatabase();
-        // For some reason app_initializer isn't creating the TimerManager with the correct database. We'll create one
-        // ourself.
-        TimerManager::freeManager();
-        TimerManager::createManager(input_db->getDatabase("TimerManager"));
 
         // Create major algorithm and data objects that comprise the
         // application.  These objects are configured from the input database.

--- a/src/FullFACPreconditioner.cpp
+++ b/src/FullFACPreconditioner.cpp
@@ -38,11 +38,9 @@
 /////////////////////////////// NAMESPACE ////////////////////////////////////
 namespace
 {
-static Timer* t_solve = TimerManager::getManager()->getTimer("IBTK::FullFACPreconditioner::solveSystem()");
-static Timer* t_initialize =
-    TimerManager::getManager()->getTimer("IBTK::FullFACPreconditioner::initializeSolverState()");
-static Timer* t_deallocate =
-    TimerManager::getManager()->getTimer("IBTK::FullFACPreconditioner::deallocateSolverState()");
+static Timer* t_solve;
+static Timer* t_initialize;
+static Timer* t_deallocate;
 } // namespace
 
 namespace IBTK


### PR DESCRIPTION
This fixes a bug found by @bindi-nagda. Some compilers will initialize the static variables before MPI is initialized, which throws an error. This delays the initialization of the timers until the class is created.