### PR TITLE
Synchronize rhs

### DIFF
--- a/frm/four_roll_mill.cpp
+++ b/frm/four_roll_mill.cpp
@@ -161,12 +161,6 @@ main(int argc, char* argv[])
                                              adv_diff_integrator,
                                              visit_data_writer);
             cf_un_forcing->setSigmaScaleFcn(stress_scale);
-            Pointer<StressRelaxation> stress_relax =
-                new StressRelaxation("StressRelax",
-                                     app_initializer->getComponentDatabase("CFINSForcing"),
-                                     ins_integrator->getNetworkVariable(),
-                                     ins_integrator);
-            cf_un_forcing->registerRelaxationOperator(stress_relax);
             ins_integrator->setForcingFunctions(cf_un_forcing, nullptr);
         }
 


### PR DESCRIPTION
Synchronizes the RHS before solving the momentum equation. This seems to fix some problems with AMR.

This also removes the incorrect relaxation operator in the four roll mill example.