### PR TITLE
Add support for BDF2 in momentum equation

### DIFF
--- a/convective_op/convective_op.cpp
+++ b/convective_op/convective_op.cpp
@@ -237,7 +237,7 @@ main(int argc, char* argv[])
 
         convec_op.approximateConvectiveOperator(N_un_idx,
                                                 N_us_idx,
-                                                TimeSteppingType::FORWARD_EULER,
+                                                IBAMR::TimeSteppingType::FORWARD_EULER,
                                                 0.0,
                                                 1.0,
                                                 un_idx,

--- a/include/multiphase/MultiphaseStaggeredHierarchyIntegrator.h
+++ b/include/multiphase/MultiphaseStaggeredHierarchyIntegrator.h
@@ -404,7 +404,6 @@ private:
      * BDF2 patch data. Note that for second order accuracy, we need
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_un_old_var, d_us_old_var;
-    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_thn_old_var;
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_fn_old_var, d_fs_old_var;
 
     // Scratch force index

--- a/include/multiphase/MultiphaseStaggeredHierarchyIntegrator.h
+++ b/include/multiphase/MultiphaseStaggeredHierarchyIntegrator.h
@@ -274,6 +274,13 @@ private:
                         int us_new_idx,
                         int thn_new_idx);
 
+    void addBodyForces(SAMRAI::tbox::Pointer<SAMRAI::solv::SAMRAIVectorReal<NDIM, double>>& f_vec,
+                       double current_time,
+                       double new_time,
+                       int thn_cur_idx,
+                       int thn_half_idx,
+                       int thn_new_idx);
+
     /*!
      * \brief Default constructor.
      *
@@ -394,9 +401,11 @@ private:
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_Nn_old_var, d_Ns_old_var;
 
     /*!
-     * BDF2 patch data for velocity
+     * BDF2 patch data. Note that for second order accuracy, we need
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_un_old_var, d_us_old_var;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::CellVariable<NDIM, double>> d_thn_old_var;
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_fn_old_var, d_fs_old_var;
 
     // Scratch force index
     int d_fn_scr_idx = IBTK::invalid_index, d_fs_scr_idx = IBTK::invalid_index;

--- a/include/multiphase/MultiphaseStaggeredHierarchyIntegrator.h
+++ b/include/multiphase/MultiphaseStaggeredHierarchyIntegrator.h
@@ -9,6 +9,7 @@
 #include "multiphase/MultiphaseConvectiveManager.h"
 #include "multiphase/MultiphaseStaggeredStokesBoxRelaxationFACOperator.h"
 #include "multiphase/MultiphaseStaggeredStokesOperator.h"
+#include "multiphase/utility_functions.h"
 
 #include "ibamr/INSHierarchyIntegrator.h"
 #include "ibamr/StaggeredStokesPhysicalBoundaryHelper.h"
@@ -392,6 +393,11 @@ private:
      */
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_Nn_old_var, d_Ns_old_var;
 
+    /*!
+     * BDF2 patch data for velocity
+     */
+    SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_un_old_var, d_us_old_var;
+
     // Scratch force index
     int d_fn_scr_idx = IBTK::invalid_index, d_fs_scr_idx = IBTK::invalid_index;
 
@@ -403,6 +409,8 @@ private:
     // Variable drag coefficient.
     SAMRAI::tbox::Pointer<SAMRAI::pdat::SideVariable<NDIM, double>> d_xi_var;
     SAMRAI::tbox::Pointer<IBTK::CartGridFunction> d_xi_fcn;
+
+    TimeSteppingType d_viscous_ts_type = TimeSteppingType::TRAPEZOIDAL_RULE;
 };
 } // namespace multiphase
 

--- a/include/multiphase/utility_functions.h
+++ b/include/multiphase/utility_functions.h
@@ -185,6 +185,60 @@ void deallocate_patch_data(const int idx,
                            int finest_ln);
 //\}
 
+template <typename T>
+inline T
+string_to_enum(const std::string& /*val*/)
+{
+    TBOX_ERROR("UNSUPPORTED ENUM TYPE\n");
+    return -1;
+} // string_to_enum
+
+template <typename T>
+inline std::string
+enum_to_string(T /*val*/)
+{
+    TBOX_ERROR("UNSUPPORTED ENUM TYPE\n");
+    return "UNKNOWN";
+} // enum_to_string
+
+enum class TimeSteppingType
+{
+    ADAMS_BASHFORTH,
+    BACKWARD_EULER,
+    FORWARD_EULER,
+    MIDPOINT_RULE,
+    TRAPEZOIDAL_RULE,
+    BDF2,
+    UNKNOWN_TIME_STEPPING_TYPE = -1
+};
+
+template <>
+inline TimeSteppingType
+string_to_enum<TimeSteppingType>(const std::string& val)
+{
+    if (strcasecmp(val.c_str(), "ADAMS_BASHFORTH") == 0) return TimeSteppingType::ADAMS_BASHFORTH;
+    if (strcasecmp(val.c_str(), "BACKWARD_EULER") == 0) return TimeSteppingType::BACKWARD_EULER;
+    if (strcasecmp(val.c_str(), "FORWARD_EULER") == 0) return TimeSteppingType::FORWARD_EULER;
+    if (strcasecmp(val.c_str(), "MIDPOINT_RULE") == 0) return TimeSteppingType::MIDPOINT_RULE;
+    if (strcasecmp(val.c_str(), "TRAPEZOIDAL_RULE") == 0) return TimeSteppingType::TRAPEZOIDAL_RULE;
+    if (strcasecmp(val.c_str(), "CRANK_NICOLSON") == 0) return TimeSteppingType::TRAPEZOIDAL_RULE;
+    if (strcasecmp(val.c_str(), "BDF2") == 0) return TimeSteppingType::BDF2;
+    return TimeSteppingType::UNKNOWN_TIME_STEPPING_TYPE;
+} // string_to_enum
+
+template <>
+inline std::string
+enum_to_string<TimeSteppingType>(TimeSteppingType val)
+{
+    if (val == TimeSteppingType::ADAMS_BASHFORTH) return "ADAMS_BASHFORTH";
+    if (val == TimeSteppingType::BACKWARD_EULER) return "BACKWARD_EULER";
+    if (val == TimeSteppingType::FORWARD_EULER) return "FORWARD_EULER";
+    if (val == TimeSteppingType::MIDPOINT_RULE) return "MIDPOINT_RULE";
+    if (val == TimeSteppingType::TRAPEZOIDAL_RULE) return "TRAPEZOIDAL_RULE";
+    if (val == TimeSteppingType::BDF2) return "BDF2";
+    return "UNKNOWN_TIME_STEPPING_TYPE";
+} // enum_to_string
+
 } // namespace multiphase
 
 #include "multiphase/private/utility_functions_inc.h"

--- a/src/MultiphaseStaggeredHierarchyIntegrator.cpp
+++ b/src/MultiphaseStaggeredHierarchyIntegrator.cpp
@@ -1178,7 +1178,7 @@ MultiphaseStaggeredHierarchyIntegrator::postprocessIntegrateHierarchy(const doub
         current_time, new_time, skip_synchronize_new_state_data, num_cycles);
 
     // Replace N_old data if necessary
-    if (is_multistep_time_stepping_type(d_convective_time_stepping_type))
+    if (!d_creeping_flow && is_multistep_time_stepping_type(d_convective_time_stepping_type))
     {
         auto var_db = VariableDatabase<NDIM>::getDatabase();
         const int Nn_old_idx = var_db->mapVariableAndContextToIndex(d_Nn_old_var, getCurrentContext());

--- a/tests/convective_op/convective_op.cpp
+++ b/tests/convective_op/convective_op.cpp
@@ -237,7 +237,7 @@ main(int argc, char* argv[])
 
         convec_op.approximateConvectiveOperator(N_un_idx,
                                                 N_us_idx,
-                                                TimeSteppingType::FORWARD_EULER,
+                                                IBAMR::TimeSteppingType::FORWARD_EULER,
                                                 0.0,
                                                 1.0,
                                                 un_idx,

--- a/tests/time_stepping/time_stepping_2d.convec.varThn.amrGrid.bdf2.input
+++ b/tests/time_stepping/time_stepping_2d.convec.varThn.amrGrid.bdf2.input
@@ -1,0 +1,161 @@
+USING_VAR_XI = FALSE
+
+USE_PRECONDITIONER =  TRUE
+W = 0.75  // under relaxation factor for box relaxation scheme
+RHO = 1.0
+N = 16
+MAX_MULTIGRID_LEVELS = 4
+START_TIME = 0.0
+NUM_CYCLES = 1
+DX = 1.0 / N 
+U_MAX = 1.0 
+CFL = 0.3
+DT_MAX = CFL * DX / U_MAX
+END_TIME = 5*DT_MAX
+ENABLE_LOGGING = TRUE
+DIR_NAME = "viz2d"
+VIZ_DUMP_TIME_INTERVAL = 0.02
+VISCOUS_TIME_STEPPING_TYPE = "BDF2"
+
+CREEPING_FLOW = FALSE
+
+ETA_S = 0.1
+ETA_N = 1.0
+NU = 1.0
+XI = 250.0*ETA_S
+
+// Inital conditions
+un {
+   function_0 = "cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t))"
+   function_1 = "sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t))"
+}
+
+us {
+   function_0 = "-cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t))"
+   function_1 = "-sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t))"
+} 
+
+p {
+   function = "0.0"
+} 
+
+f_un {
+   xi = XI
+   nu  = NU
+   etan = ETA_N
+   etas = ETA_S
+   function_0 = "-(1/(128*nu))*(128*nu*PI*cos(2*PI*(t-X_0))*cos(2*PI*(t-X_1))+32*nu*PI*(cos(4*PI*(t-X_0))-2*sin(4*PI*(t-X_0)))-32*nu*PI*cos(4*PI*(t-X_1))*(cos(4*PI*(t-X_0))+4*(-1+etan*PI)*sin(4*PI*(t-X_0)))+((8*nu*PI*(1+64*etan*PI)+61*xi)*cos(2*PI*(t-X_0))+(40*nu*PI+3*xi)*cos(6*PI*(t-X_0))-128*nu*PI*sin(2*PI*(t-X_0)))*sin(2*PI*(t-X_1))+32*nu*PI*sin(4*PI*(t-X_0))*sin(4*PI*(t-X_1))-2*cos(2*PI*(t-X_0))*(-16*nu*PI-xi+(24*nu*PI+xi)*cos(4*PI*(t-X_0)))*sin(6*PI*(t-X_1)))"
+   function_1 = "(1/(8*nu))*(1/8*(8*nu*PI+xi-(24*nu*PI+xi)*cos(4*PI*(-t+X_0)))*cos(6*PI*(-t+X_1))*sin(2*PI*(-t+X_0))-4*nu*PI*cos(4*PI*(-t+X_1))*sin(2*PI*(-t+X_0))^2+1/16*cos(2*PI*(-t+X_1))*(-128*nu*PI*cos(2*PI*(-t+X_0))+(8*nu*PI*(1+64*etan*PI)+61*xi)*sin(2*PI*(-t+X_0))+(8*nu*PI+xi)*sin(6*PI*(-t+X_0)))+8*nu*PI*sin(2*PI*(-t+X_0))*sin(2*PI*(-t+X_1))-2*nu*PI*(2+4*(-1+etan*PI)*cos(4*PI*(-t+X_0))+sin(4*PI*(-t+X_0)))*sin(4*PI*(-t+X_1)))"
+}
+
+f_us {
+   xi = XI
+   nu  = NU
+   etan = ETA_N
+   etas = ETA_S
+   function_0 = "(1/(128*nu))*(128*nu*PI*cos(2*PI*(t-X_0))*cos(2*PI*(t-X_1))-32*nu*PI*(cos(4*PI*(t-X_0))-2*sin(4*PI*(t-X_0)))+32*nu*PI*cos(4*PI*(t-X_1))*(cos(4*PI*(t-X_0))+4*(-1+etas*PI)*sin(4*PI*(t-X_0)))+((8*nu*PI*(1+64*etas*PI)+61*xi)*cos(2*PI*(t-X_0))+(40*nu*PI+3*xi)*cos(6*PI*(t-X_0))-128*nu*PI*sin(2*PI*(t-X_0)))*sin(2*PI*(t-X_1))-32*nu*PI*sin(4*PI*(t-X_0))*sin(4*PI*(t-X_1))+2*cos(2*PI*(t-X_0))*(16*nu*PI+xi-(24*nu*PI+xi)*cos(4*PI*(t-X_0)))*sin(6*PI*(t-X_1)))"
+   function_1 = "(1/(8*nu))*(1/16*cos(2*PI*(t-X_1))*(128*nu*PI*cos(2*PI*(t-X_0))+(8*nu*PI*(1+64*etas*PI)+61*xi)*sin(2*PI*(t-X_0))+(8*nu*PI+xi)*sin(6*PI*(t-X_0)))+1/8*(-8*nu*PI-xi+(24*nu*PI+xi)*cos(4*PI*(-t+X_0)))*cos(6*PI*(-t+X_1))*sin(2*PI*(-t+X_0))-4*nu*PI*cos(4*PI*(-t+X_1))*sin(2*PI*(-t+X_0))^2-8*nu*PI*sin(2*PI*(-t+X_0))*sin(2*PI*(-t+X_1))-2*nu*PI*(2+4*(-1+etas*PI)*cos(4*PI*(-t+X_0))+sin(4*PI*(-t+X_0)))*sin(4*PI*(-t+X_1)))"
+}
+
+f_p {
+   function = "1/2*PI*(cos(4*PI*(-t+X_0))-cos(4*PI*(X_0-X_1))+cos(4*PI*(-t+X_1))-cos(4*PI*(-2*t+X_0+X_1)))"
+}
+
+thn {
+   function = "1/2+1/4*sin(2*PI*(X_0-t))*sin(2*PI*(X_1-t))"
+}
+
+INSVCTwoFluidStaggeredHierarchyIntegrator {
+   creeping_flow                 = CREEPING_FLOW
+   convec_limiter_type           = "CUI"
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   num_cycles                    = NUM_CYCLES
+   dt_max                        = DT_MAX
+   enable_logging                = ENABLE_LOGGING
+   w = W
+   use_preconditioner = USE_PRECONDITIONER
+   viscous_time_stepping_type = VISCOUS_TIME_STEPPING_TYPE
+   regrid_interval = 1000000000
+   convec_ts_type = "ADAMS_BASHFORTH"
+
+   solver_db {
+      ksp_type = "fgmres"
+   }
+
+   precond_db {
+      cycle_type = "V_CYCLE"
+      num_pre_sweeps = 3
+      num_post_sweeps = 3
+      enable_logging = TRUE
+      max_multigrid_levels = MAX_MULTIGRID_LEVELS
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name = "output"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer = "VisIt"
+   viz_dump_dirname = DIR_NAME
+   visit_number_procs_per_file = 1
+
+// timer dump parameters
+   timer_enabled = TRUE
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = -0.5, -0.5      // lower end of computational domain.
+   x_up               = 0.5, 0.5        // upper end of computational domain.
+   periodic_dimension = 1, 1  
+}
+
+GriddingAlgorithm {
+   max_levels = 2              // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 2, 2              // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 512, 512          // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4          // smallest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+    // level_0 = [( N/4 , N/4 ),( 3*N/4 - 1 , N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1, 3*N/4 - 2)]
+    // level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )] // L-shaped refinement
+    // level_0 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+    // level_0 = [(N/4 + 5 , N/4 + 5),( N/4 + 10, N/4 + 10)] 
+    // level_0 = [(1,1), (30,30)] 
+    // level_1 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+   }
+}
+
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1 
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 1.0
+   timer_list = "IBTK::*::*"
+}

--- a/tests/time_stepping/time_stepping_2d.convec.varThn.amrGrid.bdf2.output
+++ b/tests/time_stepping/time_stepping_2d.convec.varThn.amrGrid.bdf2.output
@@ -1,0 +1,16 @@
+Printing error norms
+
+Network velocity
+Un L1-norm:  0.0338662
+Un L2-norm:  0.0275531
+Un max-norm: 0.0341283
+
+Solvent velocity
+Us L1-norm:  0.0363659
+Us L2-norm:  0.0292121
+Us max-norm: 0.0384011
+
+Pressure
+P L1-norm:  0.0594037
+P L2-norm:  0.0749451
+P max-norm: 0.178328

--- a/tests/time_stepping/time_stepping_2d.uniThn.bdf2.input
+++ b/tests/time_stepping/time_stepping_2d.uniThn.bdf2.input
@@ -1,0 +1,161 @@
+USING_VAR_XI = FALSE
+
+USE_PRECONDITIONER =  TRUE
+W = 0.75  // under relaxation factor for box relaxation scheme
+RHO = 1.0
+N = 16
+MAX_MULTIGRID_LEVELS = 5
+PRECONDITIONER_COARSENING_OP = "CONSERVATIVE_COARSEN"
+START_TIME = 0.0
+NUM_CYCLES = 1
+DX = 1.0 / N 
+U_MAX = 1.0 
+CFL = 0.5
+DT_MAX = CFL * DX / U_MAX 
+END_TIME = 5*DT_MAX
+ENABLE_LOGGING = FALSE
+DIR_NAME = "viz2d"
+VIZ_DUMP_TIME_INTERVAL = 0.1
+VISCOUS_TIME_STEPPING_TYPE = "BDF2"
+
+ETA_S = 0.004
+ETA_N = 4.0
+NU = 1.0
+XI = 250.0*ETA_S
+
+// Inital conditions
+un {
+   function_0 = "sin(2*PI*(X_0 - t)) * cos(2*PI*( X_1 - t))"
+   function_1 = "cos(2*PI*(X_0 - t)) * sin(2*PI*( X_1 - t))"
+}
+
+us {
+   function_0 = "-sin(2*PI*(X_0 - t)) * cos(2*PI*( X_1 - t))"
+   function_1 = "-sin(2*PI*(X_0 - t)) * cos(2*PI*( X_1 - t))"
+} 
+
+p {
+   function = "0.0"
+} 
+
+f_un {
+   xi = XI
+   nu  = NU
+   eta_n = ETA_N
+   etas = ETA_S
+   function_0 = "(3*(-8*nu*PI*cos(2*PI*(-2*t+X_0+X_1))+(16*eta_n*nu*PI^2+xi)*(sin(2*PI*(X_0-X_1))+sin(2*PI*(-2*t+X_0+X_1)))))/(16*nu)"
+   function_1 = "3/16*(-8*PI*(cos(2*PI*(-2*t+X_0+X_1))+2*eta_n*PI*sin(2*PI*(X_0-X_1)))+((16*eta_n*nu*PI^2+xi)*sin(2*PI*(-2*t+X_0+X_1)))/nu)"
+}
+
+f_us {
+   xi = XI
+   nu  = NU
+   eta_n = ETA_N
+   etas = ETA_S
+   function_0 = "1/8*(4*PI*cos(2*PI*(t-X_0))*cos(2*PI*(t-X_1))+(sin(2*PI*(t-X_0))*((16*etas*nu*PI^2+3*xi)*cos(2*PI*(t-X_1))-4*nu*PI*sin(2*PI*(t-X_1))))/nu)"
+   function_1 = "1/2*PI*cos(2*PI*(-2*t+X_0+X_1))-etas*PI^2*sin(2*PI*(X_0-X_1))-((16*etas*nu*PI^2+3*xi)*sin(2*PI*(-2*t+X_0+X_1)))/(16*nu)"
+}
+
+f_p {
+   function = "3/2*PI*cos(2*PI*(X_0-X_1))+PI*cos(2*PI*(-2*t+X_0+X_1))"
+}
+
+thn {
+   function = "0.75"
+}
+
+INSVCTwoFluidStaggeredHierarchyIntegrator {
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   num_cycles                    = NUM_CYCLES
+   dt_max                        = DT_MAX
+   enable_logging                = ENABLE_LOGGING
+   w = W
+   use_preconditioner = USE_PRECONDITIONER
+   viscous_time_stepping_type = VISCOUS_TIME_STEPPING_TYPE
+   regrid_interval = 1000000000
+
+   solver_db {
+      ksp_type = "fgmres"
+   }
+
+   precond_db {
+      cycle_type = "V_CYCLE"
+      num_pre_sweeps = 3
+      num_post_sweeps = 3
+      enable_logging = FALSE
+      max_multigrid_levels = MAX_MULTIGRID_LEVELS
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name = "logfile"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer = "VisIt"
+   viz_dump_dirname = DIR_NAME
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 1
+   restart_dump_dirname        = "restart_viz2d"
+
+// timer dump parameters
+   timer_enabled = TRUE
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = -0.5, -0.5      // lower end of computational domain.
+   x_up               = 0.5, 0.5        // upper end of computational domain.
+   periodic_dimension = 1, 1  
+}
+
+GriddingAlgorithm {
+   max_levels = 2              // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 4, 4              // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 512, 512          // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4          // smallest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+    // level_0 = [( N/4 , N/4 ),( 3*N/4 - 1 , N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1, 3*N/4 - 2)]
+    level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )] // L-shaped refinement
+    // level_0 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+    // level_0 = [(N/4 + 5 , N/4 + 5),( N/4 + 10, N/4 + 10)] 
+    // level_0 = [(1,1), (14,14)] 
+    // level_1 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+   }
+}
+
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1 
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 1.0
+   timer_list = "IBTK::*::*"
+}

--- a/tests/time_stepping/time_stepping_2d.uniThn.bdf2.output
+++ b/tests/time_stepping/time_stepping_2d.uniThn.bdf2.output
@@ -1,0 +1,16 @@
+Printing error norms
+
+Network velocity
+Un L1-norm:  0.105974
+Un L2-norm:  0.0833569
+Un max-norm: 0.0937118
+
+Solvent velocity
+Us L1-norm:  0.308269
+Us L2-norm:  0.241884
+Us max-norm: 0.251238
+
+Pressure
+P L1-norm:  0.259402
+P L2-norm:  0.291031
+P max-norm: 0.424667

--- a/tests/time_stepping/time_stepping_2d.uniThn.bdf2.output
+++ b/tests/time_stepping/time_stepping_2d.uniThn.bdf2.output
@@ -1,16 +1,16 @@
 Printing error norms
 
 Network velocity
-Un L1-norm:  0.105974
-Un L2-norm:  0.0833569
-Un max-norm: 0.0937118
+Un L1-norm:  0.104575
+Un L2-norm:  0.0822785
+Un max-norm: 0.0927435
 
 Solvent velocity
-Us L1-norm:  0.308269
-Us L2-norm:  0.241884
-Us max-norm: 0.251238
+Us L1-norm:  0.303983
+Us L2-norm:  0.238607
+Us max-norm: 0.248044
 
 Pressure
-P L1-norm:  0.259402
-P L2-norm:  0.291031
-P max-norm: 0.424667
+P L1-norm:  0.268781
+P L2-norm:  0.298033
+P max-norm: 0.432507

--- a/tests/time_stepping/time_stepping_2d.varThn.bdf2.input
+++ b/tests/time_stepping/time_stepping_2d.varThn.bdf2.input
@@ -1,0 +1,161 @@
+USING_VAR_XI = FALSE
+
+USE_PRECONDITIONER =  TRUE
+W = 0.75  // under relaxation factor for box relaxation scheme
+RHO = 1.0
+N = 32
+MAX_MULTIGRID_LEVELS = 5
+PRECONDITIONER_COARSENING_OP = "CONSERVATIVE_COARSEN"
+START_TIME = 0.0
+NUM_CYCLES = 1
+DX = 1.0 / N 
+U_MAX = 1.0 
+CFL = 0.5
+DT_MAX = CFL * DX / U_MAX 
+END_TIME = 5 * DT_MAX
+ENABLE_LOGGING = FALSE
+DIR_NAME = "viz2d"
+VIZ_DUMP_TIME_INTERVAL = 0.2
+VISCOUS_TIME_STEPPING_TYPE = "BDF2"
+
+ETA_S = 0.01
+ETA_N = 1.0
+NU = 1.0
+XI = 250.0*ETA_S
+
+// Inital conditions
+un {
+   function_0 = "cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t))"
+   function_1 = "sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t))"
+}
+
+us {
+   function_0 = "-cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t))"
+   function_1 = "-sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t))"
+} 
+
+p {
+   function = "0.0"
+} 
+
+f_un {
+   xi = XI
+   nu = NU
+   etan = ETA_N
+   etas = ETA_S
+   function_0 = "(1/(8*nu))*(-4*nu*PI*cos(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^2+cos(2*PI*(-t+X_0))*(-8*nu*PI*cos(2*PI*(-t+X_1))+4*(8*etan*nu*PI^2+xi)*sin(2*PI*(-t+X_1))-xi*sin(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^3)+2*nu*PI*(-4*etan*PI*cos(2*PI*(-t+X_1))^2*sin(4*PI*(-t+X_0))+4*sin(2*PI*(-t+X_0))*sin(2*PI*(-t+X_1))+2*sin(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^2+sin(4*PI*(-t+X_0))*(4*etan*PI*sin(2*PI*(-t+X_1))^2-sin(4*PI*(-t+X_1)))))"
+   function_1 = "1/8*(-8*PI*cos(2*PI*(-t+X_0))*cos(2*PI*(-t+X_1))-4*PI*cos(2*PI*(-t+X_1))^2*sin(2*PI*(-t+X_0))^2+(cos(2*PI*(-t+X_1))*sin(2*PI*(-t+X_0))*(4*(8*etan*nu*PI^2+xi)-xi*sin(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^2))/nu-8*etan*PI^2*cos(2*PI*(-t+X_0))^2*sin(4*PI*(-t+X_1))+2*PI*(4*sin(2*PI*(-t+X_0))*sin(2*PI*(-t+X_1))-sin(4*PI*(-t+X_0))*sin(4*PI*(-t+X_1))+2*sin(2*PI*(-t+X_0))^2*(sin(2*PI*(-t+X_1))^2+2*etan*PI*sin(4*PI*(-t+X_1)))))"
+}
+
+f_us {
+   xi = XI
+   nu = NU
+   etan = ETA_N
+   etas = ETA_S
+   function_0 = "(1/(8*nu))*(-4*nu*PI*cos(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^2+cos(2*PI*(-t+X_0))*(8*nu*PI*cos(2*PI*(-t+X_1))-4*(8*etas*nu*PI^2+xi)*sin(2*PI*(-t+X_1))+xi*sin(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^3)-2*nu*PI*(4*etas*PI*cos(2*PI*(-t+X_1))^2*sin(4*PI*(-t+X_0))+4*sin(2*PI*(-t+X_0))*sin(2*PI*(-t+X_1))-2*sin(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^2+sin(4*PI*(-t+X_0))*(-4*etas*PI*sin(2*PI*(-t+X_1))^2+sin(4*PI*(-t+X_1)))))"
+   function_1 = "1/8*(8*PI*cos(2*PI*(-t+X_0))*cos(2*PI*(-t+X_1))-4*PI*cos(2*PI*(-t+X_1))^2*sin(2*PI*(-t+X_0))^2+(cos(2*PI*(-t+X_1))*sin(2*PI*(-t+X_0))*(-4*(8*etas*nu*PI^2+xi)+xi*sin(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^2))/nu-8*etas*PI^2*cos(2*PI*(-t+X_0))^2*sin(4*PI*(-t+X_1))+2*PI*(-4*sin(2*PI*(-t+X_0))*sin(2*PI*(-t+X_1))-sin(4*PI*(-t+X_0))*sin(4*PI*(-t+X_1))+2*sin(2*PI*(-t+X_0))^2*(sin(2*PI*(-t+X_1))^2+2*etas*PI*sin(4*PI*(-t+X_1)))))"
+}
+
+f_p {
+   function = "1/2*PI*(cos(4*PI*(-t+X_0))-cos(4*PI*(X_0-X_1))+cos(4*PI*(-t+X_1))-cos(4*PI*(-2*t+X_0+X_1)))"
+}
+
+thn {
+   function = "0.25*sin(2*PI*(X_0-t))*sin(2*PI*(X_1-t)) + 0.5"
+}
+
+INSVCTwoFluidStaggeredHierarchyIntegrator {
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   num_cycles                    = NUM_CYCLES
+   dt_max                        = DT_MAX
+   enable_logging                = ENABLE_LOGGING
+   w = W
+   use_preconditioner = USE_PRECONDITIONER
+   viscous_time_stepping_type = VISCOUS_TIME_STEPPING_TYPE
+   regrid_interval = 1000000000
+
+   solver_db {
+      ksp_type = "fgmres"
+   }
+
+   precond_db {
+      cycle_type = "V_CYCLE"
+      num_pre_sweeps = 3
+      num_post_sweeps = 3
+      enable_logging = FALSE
+      max_multigrid_levels = MAX_MULTIGRID_LEVELS
+   }
+}
+
+Main {
+// log file parameters
+   log_file_name = "logfile"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer = "VisIt"
+   viz_dump_dirname = DIR_NAME
+   visit_number_procs_per_file = 1
+
+// restart dump parameters
+   restart_dump_interval       = 5
+   restart_dump_dirname        = "restart_viz2d"
+
+// timer dump parameters
+   timer_enabled = TRUE
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = -0.5, -0.5      // lower end of computational domain.
+   x_up               = 0.5, 0.5        // upper end of computational domain.
+   periodic_dimension = 1, 1  
+}
+
+GriddingAlgorithm {
+   max_levels = 1              // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 4, 4              // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 512, 512          // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4          // smallest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+    // level_0 = [( N/4 , N/4 ),( 3*N/4 - 1 , N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1, 3*N/4 - 2)]
+    level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )] // L-shaped refinement
+    // level_0 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+    // level_0 = [(N/4 + 5 , N/4 + 5),( N/4 + 10, N/4 + 10)] 
+    // level_0 = [(1,1), (30,30)] 
+    // level_1 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+   }
+}
+
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1 
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 1.0
+   timer_list = "IBTK::*::*"
+}

--- a/tests/time_stepping/time_stepping_2d.varThn.bdf2.output
+++ b/tests/time_stepping/time_stepping_2d.varThn.bdf2.output
@@ -1,0 +1,16 @@
+Printing error norms
+
+Network velocity
+Un L1-norm:  0.0210397
+Un L2-norm:  0.0164922
+Un max-norm: 0.0198747
+
+Solvent velocity
+Us L1-norm:  0.0219956
+Us L2-norm:  0.018438
+Us max-norm: 0.0325477
+
+Pressure
+P L1-norm:  0.0504117
+P L2-norm:  0.059301
+P max-norm: 0.148115

--- a/tests/time_stepping_thn/time_stepping_thn_2d.advectThn.bdf2.input
+++ b/tests/time_stepping_thn/time_stepping_thn_2d.advectThn.bdf2.input
@@ -1,0 +1,187 @@
+USING_VAR_XI = FALSE
+
+RHO = 1.0
+START_TIME = 0.0
+NUM_CYCLES = 1
+N = 16
+MAX_MULTIGRID_LEVELS = 3
+PRECONDITIONER_COARSENING_OP = "CONSERVATIVE_COARSEN"
+DX = 1.0 / N
+U_MAX = 1.0
+CFL = 0.1
+DT_MAX = CFL * DX / U_MAX
+END_TIME = 5*DT_MAX
+ENABLE_LOGGING = TRUE
+W = 0.75
+USE_PRECONDITIONER = TRUE
+VIZ_DUMP_TIME_INTERVAL = 0.05
+DELTA = 0.175
+TAG_BUFFER = 1
+
+VISCOUS_TS_TYPE = "BDF2"
+
+ADV_DIFF_NUM_CYCLES = 1
+ADV_DIFF_CONVECTIVE_OP_TYPE = "CUI"
+ADV_DIFF_CONVECTIVE_TS_TYPE = "ADAMS_BASHFORTH"
+ADV_DIFF_CONVECTIVE_FORM = "CONSERVATIVE"
+
+ETA_S = 0.4
+ETA_N = 4.0
+NU = 1.0
+XI = 250.0*ETA_S
+
+un {
+   function_0 = "cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t))"
+   function_1 = "sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t))"
+}
+
+us {
+   function_0 = "-cos(2*PI*(X_0-t))*sin(2*PI*(X_1-t))"
+   function_1 = "-sin(2*PI*(X_0-t))*cos(2*PI*(X_1-t))"
+} // so that average of un + us is 0
+
+p {
+   function = "0.0"
+} // pressure has mean 0
+
+f_un {
+   xi = XI
+   nu = NU
+   etan = ETA_N
+   etas = ETA_S
+   function_0 = "(1/(8*nu))*(8*nu*PI*sin(2*PI*(t-X_0))*sin(2*PI*(t-X_1))-4*nu*PI*cos(4*PI*(t-X_0))*sin(2*PI*(t-X_1))^2-1/4*xi*cos(6*PI*(t-X_0))*sin(2*PI*(t-X_1))^3+2*nu*PI*sin(4*PI*(t-X_0))*(4*etan*PI*cos(4*PI*(t-X_1))-sin(4*PI*(t-X_1)))-1/16*cos(2*PI*(t-X_0))*(128*nu*PI*cos(2*PI*(t-X_1))+(512*etan*nu*PI^2+61*xi)*sin(2*PI*(t-X_1))+xi*sin(6*PI*(t-X_1))))"
+   function_1 = "-PI*cos(2*PI*(-t+X_0))*cos(2*PI*(-t+X_1))+(sin(2*PI*(-t+X_0))*((256*etan*nu*PI^2+31*xi+xi*cos(4*PI*(t-X_0)))*cos(2*PI*(t-X_1))+32*nu*PI*cos(4*PI*(t-X_1))*sin(2*PI*(t-X_0))+2*xi*cos(6*PI*(t-X_1))*sin(2*PI*(t-X_0))^2+64*nu*PI*sin(2*PI*(-t+X_1))))/(64*nu)-1/4*PI*(4*etan*PI*cos(4*PI*(-t+X_0))+sin(4*PI*(-t+X_0)))*sin(4*PI*(-t+X_1))"
+}
+
+f_us {
+   xi = XI
+   nu = NU
+   etan = ETA_N
+   etas = ETA_S
+   function_0 = "(1/(8*nu))*(-4*nu*PI*cos(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^2+cos(2*PI*(-t+X_0))*(8*nu*PI*cos(2*PI*(-t+X_1))+4*(8*etas*nu*PI^2+xi)*sin(2*PI*(t-X_1))+xi*sin(2*PI*(-t+X_0))^2*sin(2*PI*(-t+X_1))^3)-1/2*nu*PI*(-2+2*cos(4*PI*(-t+X_0))+8*cos(2*PI*(X_0-X_1))+cos(4*PI*(X_0-X_1))+2*cos(4*PI*(-t+X_1))-8*cos(2*PI*(-2*t+X_0+X_1))-3*cos(4*PI*(-2*t+X_0+X_1))+8*etas*PI*(sin(4*PI*(X_0-X_1))+sin(4*PI*(-2*t+X_0+X_1)))))"
+
+   function_1 = "PI*cos(2*PI*(t-X_0))*cos(2*PI*(t-X_1))+(sin(2*PI*(t-X_0))*((256*etas*nu*PI^2+31*xi+xi*cos(4*PI*(t-X_0)))*cos(2*PI*(t-X_1))-32*nu*PI*cos(4*PI*(t-X_1))*sin(2*PI*(t-X_0))+2*xi*cos(6*PI*(t-X_1))*sin(2*PI*(t-X_0))^2-64*nu*PI*sin(2*PI*(t-X_1))))/(64*nu)+1/4*PI*(4*etas*PI*cos(4*PI*(t-X_0))-sin(4*PI*(t-X_0)))*sin(4*PI*(t-X_1))"
+}
+
+f_p {
+   function = "1/2*PI*(cos(4*PI*(-t+X_0))-cos(4*PI*(X_0-X_1))+cos(4*PI*(-t+X_1))-cos(4*PI*(-2*t+X_0+X_1)))"
+}
+
+thn_src {
+   function = "1/4*PI*(cos(4*PI*(-t+X_0))-4*cos(2*PI*(X_0-X_1))-cos(4*PI*(X_0-X_1))+cos(4*PI*(-t+X_1))+4*cos(2*PI*(-2*t+X_0+X_1))-cos(4*PI*(-2*t+X_0+X_1))-2*sin(2*PI*(-2*t+X_0+X_1)))"
+}
+
+thn {
+   function = "0.25*sin(2*PI*(X_0 - t))*sin(2*PI*(X_1 - t)) + 0.5"
+}
+
+INSVCTwoFluidStaggeredHierarchyIntegrator {
+   rho                           = RHO
+   start_time                    = START_TIME
+   end_time                      = END_TIME
+   num_cycles                    = NUM_CYCLES
+   dt_max                        = DT_MAX
+   enable_logging                = ENABLE_LOGGING
+   viscous_time_stepping_type = VISCOUS_TS_TYPE
+   w = W
+   use_preconditioner = USE_PRECONDITIONER
+   grad_abs_thresh = 0.75
+   use_grad_tagging = TRUE
+   tag_buffer = TAG_BUFFER
+
+   solver_db {
+      ksp_type = "fgmres"
+   }
+
+   precond_db {
+      cycle_type = "V_CYCLE"
+      num_pre_sweeps = 0
+      num_post_sweeps = 3
+      enable_logging = TRUE
+      max_multigrid_levels = MAX_MULTIGRID_LEVELS
+   }
+}
+
+AdvDiffIntegrator {
+ start_time = START_TIME
+ end_time = END_TIME
+ num_cycles = ADV_DIFF_NUM_CYCLES
+ convective_time_stepping_type = ADV_DIFF_CONVECTIVE_TS_TYPE
+ convective_op_type = ADV_DIFF_CONVECTIVE_OP_TYPE
+ convective_difference_form = ADV_DIFF_CONVECTIVE_FORM
+ dt_max = DT_MAX
+ enable_logging = ENABLE_LOGGING
+}
+
+Main {
+// log file parameters
+   log_file_name = "logfile"
+   log_all_nodes = FALSE
+
+// visualization dump parameters
+   viz_writer = "VisIt"
+   viz_dump_dirname = "viz2d"
+   visit_number_procs_per_file = 1
+
+// timer dump parameters
+   timer_enabled = TRUE
+}
+
+CartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0      // lower end of computational domain.
+   x_up               = 1, 1      // upper end of computational domain.
+   periodic_dimension = 1, 1  
+}
+
+MultigridCartesianGeometry {
+   domain_boxes       = [(0,0), (N - 1,N - 1)]
+   x_lo               = 0, 0      // lower end of computational domain.
+   x_up               = 1, 1      // upper end of computational domain.
+   periodic_dimension = 1, 1  
+}
+
+GriddingAlgorithm {
+   max_levels = 1                 // Maximum number of levels in hierarchy.
+
+   ratio_to_coarser {
+      level_1 = 2, 2              // vector ratio to next coarser level
+   }
+
+   largest_patch_size {
+      level_0 = 512, 512          // largest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   smallest_patch_size {
+      level_0 =   4,   4          // smallest patch allowed in hierarchy
+                                  // all finer levels will use same values as level_0...
+   }
+
+   efficiency_tolerance = 0.70e0  // min % of tag cells in new patch level
+   combine_efficiency   = 0.85e0  // chop box if sum of volumes of smaller
+                                  // boxes < efficiency * vol of large box
+}
+
+StandardTagAndInitialize {
+   tagging_method = "REFINE_BOXES"
+   RefineBoxes {
+    // level_0 = [( N/4 , N/4 ),( 3*N/4 - 1 , N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1, 3*N/4 - 2)]
+    level_0 = [( N/4,N/4 ),( 3*N/4 - 1,N/2 - 1 )],[( N/4,N/2 ),( N/2 - 1,3*N/4 - 1 )] // L-shaped refinement
+    // level_0 = [( N/4 , N/8 ),( 3*N/4 - 1 , 3*N/4 - 1 )] 
+    // level_0 = [(N/4 + 5 , N/4 + 5),( N/4 + 10, N/4 + 10)] 
+    // level_0 = [(1,1), (30,30)] 
+   }
+}
+
+LoadBalancer {
+   bin_pack_method = "SPATIAL"
+   max_workload_factor = 1
+}
+
+TimerManager{
+   print_exclusive = FALSE
+   print_total = TRUE
+   print_threshold = 1.0
+   timer_list = "IBTK::*::*"
+}

--- a/tests/time_stepping_thn/time_stepping_thn_2d.advectThn.bdf2.output
+++ b/tests/time_stepping_thn/time_stepping_thn_2d.advectThn.bdf2.output
@@ -1,0 +1,19 @@
+Network velocity
+Un L1-norm:  0.010097
+Un L2-norm:  0.00920951
+Un max-norm: 0.0177137
+
+Solvent velocity
+Us L1-norm:  0.0129132
+Us L2-norm:  0.0113639
+Us max-norm: 0.0193369
+
+Pressure
+P L1-norm:  0.0580864
+P L2-norm:  0.0732104
+P max-norm: 0.200079
+
+Volume fraction
+Thn L1-norm:  0.00129863
+Thn L2-norm:  0.00154453
+Thn max-norm: 0.00340736


### PR DESCRIPTION
This adds support for BDF2. I've also moved the force accumulation to a separate function. Note that `d_viscous_time_stepping_type` should not be used and has been replaced with `d_viscous_ts_type` (because IBAMR does not support BDF2 time integration yet).